### PR TITLE
feat: sync multi-unit test start

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -47,6 +47,7 @@ class K6K8sCharm(CharmBase):
 
     def _on_start_action(self, event: ActionEvent) -> None:
         """Run a load test script with `k6 run`."""
+        self.k6.initialize()
         if not self.unit.is_leader():
             event.fail("You can only run the action on the leader unit.")
             return


### PR DESCRIPTION
## Issue
When splitting up `k6` tests across multiple units, it's important to make sure they start together. Currently, each unit starts running the test as soon as the Pebble layer is set; that timing is based on when `relation-changed` events are processed by each unit, and thus have no guarantees of being executed in sync.

## Solution
All units start the `k6` test in `--paused` mode, meaning the test doesn't actually start, but `k6` is running. This allows us to use the HTTP API to `/start` the test on all units at the same time:

0. all units are initialized with "status: idle" in peer data;
1. leader puts Pebble layer (with `--paused`) in peer data;
2. all units wake up from `relation-changed`, and they:
	1. set the Pebble layer;
	2. set "status: active" in peer data;
3. on each `relation-changed` (one per unit) the leader checks if all units are "status: active", and skips if not all of them are
4. all units are "status: active", the leader calls the HTTP API on each unit to start the test

This mechanism is better illustrated by the following diagram:
![K6 Sequence Diagram drawio (2)](https://github.com/user-attachments/assets/50451d7d-fc6d-40a3-94b6-1dba10c4a360)
