### PR TITLE
feat: add support for sideloading environment variables for k6 scripts

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -57,6 +57,14 @@ config:
         A standalone k6 script that can be executed via `k6 run`.
         See examples in https://grafana.com/docs/k6/latest/examples/
         The value of this config option is used to by the `run` charm action.
+    environment:
+      type: string
+      required: false
+      description: >
+        A comma-separated list of environment variables to be used by k6 scripts.
+        These will override any variables passed over relation data.
+        Example:
+          `juju config k6 environment "ENDPOINT='http://...',FOO=bar,BAZ=42"`
 
 actions:
   start:


### PR DESCRIPTION
## Issues
Closes #6

## Solution

Add an `environment` config option that accepts a comma-separated list of environment variables to be used in `k6` scripts. These variables are not injected directly into the layer, but rather they're passed as `-e` arguments to `k6` itself.

Drive-by fixes: 
- set the `k6` workload version so that it's shown in `juju status`;
- get the `test_uuid` and `date` labels from the correct place in peer data.

Here's a screenshot of the load test logs, before and after configuring the environment (the test was manually stopped before passing the new variable):

![Screenshot-2025-03-21_18-57](https://github.com/user-attachments/assets/385616c3-fc65-4f5a-b82d-ed877c3cf20d)
