### PR TITLE
feat: change ownership to Tracing team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @canonical/Observability
+*       @canonical/tracing-and-profiling


### PR DESCRIPTION
According to the maintenance rebalancing process, the ownership of this repository is being changed from **Core** to **Tracing**.