### PR TITLE
feat(terraform): add channel validation and split outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ version
 metadata.yaml
 config.yaml
 actions.yaml
+
+# Terraform
+**/.terraform/*
+**/.terraform.lock.hcl

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -38,5 +38,6 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_app_name"></a> [app\_name](#output\_app\_name) | n/a |
-| <a name="output_endpoints"></a> [endpoints](#output\_endpoints) | n/a |
+| <a name="output_provides"></a> [provides](#output\_provides) | n/a |
+| <a name="output_requires"></a> [requires](#output\_requires) | n/a |
 <!-- END_TF_DOCS -->

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -2,11 +2,14 @@ output "app_name" {
   value = juju_application.k6.name
 }
 
-output "endpoints" {
+output "provides" {
   value = {
-    # Provides
     provide_cmr_mesh = "provide-cmr-mesh",
-    # Requires
+  }
+}
+
+output "requires" {
+  value = {
     send_remote_write = "send-remote-write",
     logging           = "logging",
     receive-k6-tests  = "receive-k6-tests",

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -7,6 +7,11 @@ variable "app_name" {
 variable "channel" {
   description = "Channel that the charm is deployed from"
   type        = string
+
+  validation {
+    condition     = startswith(var.channel, "dev/")
+    error_message = "The track of the channel must be 'dev/'. e.g. 'dev/edge'."
+  }
 }
 
 variable "config" {

--- a/tests/integration/test_self_monitoring.py
+++ b/tests/integration/test_self_monitoring.py
@@ -103,7 +103,7 @@ def _assert_prometheus_has_k6_metrics(juju: jubilant.Juju):
 def test_deploy(juju: jubilant.Juju, charm_path):
     """Deploy k6, Loki and Prometheus, then integrate them."""
     juju.deploy(charm_path, APP_NAME, resources={"k6-image": K6_IMAGE})
-    juju.deploy("loki-k8s", LOKI_APP, channel="dev/edge/pr591", trust=True, base="ubuntu@24.04:amd64")
+    juju.deploy("loki-k8s", LOKI_APP, revision=221, channel="dev/edge", trust=True)
     juju.deploy("prometheus-k8s", PROMETHEUS_APP, channel="dev/edge", trust=True)
     juju.wait(
         lambda s: jubilant.all_active(s, APP_NAME, LOKI_APP, PROMETHEUS_APP),

--- a/tests/integration/test_self_monitoring.py
+++ b/tests/integration/test_self_monitoring.py
@@ -103,7 +103,7 @@ def _assert_prometheus_has_k6_metrics(juju: jubilant.Juju):
 def test_deploy(juju: jubilant.Juju, charm_path):
     """Deploy k6, Loki and Prometheus, then integrate them."""
     juju.deploy(charm_path, APP_NAME, resources={"k6-image": K6_IMAGE})
-    juju.deploy("loki-k8s", LOKI_APP, revision=221, channel="dev/edge", trust=True)
+    juju.deploy("loki-k8s", LOKI_APP, revision=222, channel="dev/edge", trust=True)
     juju.deploy("prometheus-k8s", PROMETHEUS_APP, channel="dev/edge", trust=True)
     juju.wait(
         lambda s: jubilant.all_active(s, APP_NAME, LOKI_APP, PROMETHEUS_APP),

--- a/tests/integration/test_self_monitoring.py
+++ b/tests/integration/test_self_monitoring.py
@@ -103,7 +103,7 @@ def _assert_prometheus_has_k6_metrics(juju: jubilant.Juju):
 def test_deploy(juju: jubilant.Juju, charm_path):
     """Deploy k6, Loki and Prometheus, then integrate them."""
     juju.deploy(charm_path, APP_NAME, resources={"k6-image": K6_IMAGE})
-    juju.deploy("loki-k8s", LOKI_APP, channel="dev/edge/pr591", trust=True)
+    juju.deploy("loki-k8s", LOKI_APP, channel="dev/edge/pr591", trust=True, base="ubuntu@24.04:amd64")
     juju.deploy("prometheus-k8s", PROMETHEUS_APP, channel="dev/edge", trust=True)
     juju.wait(
         lambda s: jubilant.all_active(s, APP_NAME, LOKI_APP, PROMETHEUS_APP),

--- a/tests/integration/test_self_monitoring.py
+++ b/tests/integration/test_self_monitoring.py
@@ -103,7 +103,7 @@ def _assert_prometheus_has_k6_metrics(juju: jubilant.Juju):
 def test_deploy(juju: jubilant.Juju, charm_path):
     """Deploy k6, Loki and Prometheus, then integrate them."""
     juju.deploy(charm_path, APP_NAME, resources={"k6-image": K6_IMAGE})
-    juju.deploy("loki-k8s", LOKI_APP, channel="dev/edge", trust=True)
+    juju.deploy("loki-k8s", LOKI_APP, channel="dev/edge/pr591", trust=True)
     juju.deploy("prometheus-k8s", PROMETHEUS_APP, channel="dev/edge", trust=True)
     juju.wait(
         lambda s: jubilant.all_active(s, APP_NAME, LOKI_APP, PROMETHEUS_APP),


### PR DESCRIPTION
Add validation to the  variable in Terraform modules to ensure the  track is used.

Split the  output into separate  and  outputs.

See canonical/alertmanager-k8s-operator#403 and canonical/alertmanager-k8s-operator#396 for reference.