### PR TITLE
chore(ci): bump reusable workflows to v2

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   promote:
     name: Promote
-    uses: canonical/observability/.github/workflows/charm-promote.yaml@v1
+    uses: canonical/observability/.github/workflows/charm-promote.yaml@v2
     with:
       promotion: ${{ github.event.inputs.promotion }}
     secrets: inherit

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -9,5 +9,5 @@ on:
 jobs:
   pull-request:
     name: PR
-    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@v1
+    uses: canonical/observability/.github/workflows/charm-pull-request.yaml@v2
     secrets: inherit

--- a/.github/workflows/quality-gates.yaml
+++ b/.github/workflows/quality-gates.yaml
@@ -12,5 +12,5 @@ on:
 jobs:
   quality-gates:
     name: Run quality gates
-    uses: canonical/observability/.github/workflows/charm-quality-gates.yaml@v1
+    uses: canonical/observability/.github/workflows/charm-quality-gates.yaml@v2
     secrets: inherit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   release:
-    uses: canonical/observability/.github/workflows/charm-release.yaml@v1
+    uses: canonical/observability/.github/workflows/charm-release.yaml@v2
     secrets: inherit
     with:
       default-track: dev

--- a/.github/workflows/tiobe-scan.yaml
+++ b/.github/workflows/tiobe-scan.yaml
@@ -8,5 +8,5 @@ on:
 jobs:
     tics:
         name: TiCs
-        uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@main
+        uses: canonical/observability/.github/workflows/charm-tiobe-scan.yaml@v2
         secrets: inherit

--- a/.github/workflows/update-libs.yaml
+++ b/.github/workflows/update-libs.yaml
@@ -9,5 +9,5 @@ on:
 jobs:
   update-lib:
     name: Check libraries
-    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@v1
+    uses: canonical/observability/.github/workflows/charm-update-libs.yaml@v2
     secrets: inherit


### PR DESCRIPTION
Update all `canonical/observability` reusable workflow references to use the `v2` tag.