### PR TITLE
fix: update charm libs and add peer_relation_name param

### DIFF
--- a/lib/charms/istio_beacon_k8s/v0/service_mesh.py
+++ b/lib/charms/istio_beacon_k8s/v0/service_mesh.py
@@ -143,30 +143,63 @@ for policy in self._mesh.mesh_info():
 """
 
 import enum
+import hashlib
 import json
 import logging
 import warnings
-from typing import Dict, List, Literal, Optional, Union
+from typing import Dict, List, Literal, Optional, Set, Type, Union
 
 import httpx
 import pydantic
+from charmed_service_mesh_helpers.models import (
+    AuthorizationPolicySpec,
+    From,
+    Operation,
+    PolicyTargetReference,
+    Rule,
+    Source,
+    To,
+    WorkloadSelector,
+)
 from lightkube import Client
 from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.apps_v1 import StatefulSet
 from lightkube.resources.core_v1 import ConfigMap, Service
+from lightkube_extensions.batch import KubernetesResourceManager
+from lightkube_extensions.types import (
+    AuthorizationPolicy,
+    LightkubeResourcesList,
+    LightkubeResourceTypesSet,
+)
 from ops import CharmBase, Object, RelationMapping
+from pydantic import Field
+
+POLICY_RESOURCE_TYPES = {
+    "istio": {AuthorizationPolicy},
+}
 
 LIBID = "3f40cb7e3569454a92ac2541c5ca0a0c"  # Never change this
 LIBAPI = 0
-LIBPATCH = 8
+LIBPATCH = 19
 
-PYDEPS = ["lightkube", "pydantic"]
+PYDEPS = [
+    "lightkube",
+    "pydantic",
+    "charmed-service-mesh-helpers",
+    "lightkube-extensions",
+]
 
 logger = logging.getLogger(__name__)
 
 # Juju application names are limited to 63 characters, so we can use the app_name directly here and still keep under
 # Kubernetes's 253 character limit.
 label_configmap_name_template = "juju-service-mesh-{app_name}-labels"
+
+
+class MeshType(str, enum.Enum):
+    """Supported mesh types."""
+
+    istio = "istio"
 
 
 class Method(str, enum.Enum):
@@ -208,7 +241,7 @@ class Policy(pydantic.BaseModel):
 
     def __init__(self, **data):
         warnings.warn(
-            "Polcy is deprecated. Use AppPolicy for fine-grained application-level policies "
+            "Policy is deprecated. Use AppPolicy for fine-grained application-level policies "
             "or UnitPolicy to allow access to charm units. For migration, Policy can be "
             "directly replaced with AppPolicy.",
             DeprecationWarning,
@@ -230,21 +263,68 @@ class UnitPolicy(pydantic.BaseModel):
 
     relation: str
     # UnitPolicy at the moment only supports access control over ports.
-    # This limitation stems from the currenlty supported upstream service meshes (Istio).
+    # This limitation stems from the currently supported upstream service meshes (Istio).
     # Since other attributes of Endpoints class are not supported, the easiest implementation was to use just the ports attribute in this class.
     ports: Optional[List[int]] = None
 
 
 class MeshPolicy(pydantic.BaseModel):
-    """Data type for storage service mesh policy information."""
+    """A Generic MeshPolicy data type that describes mesh policies in a way that is agnostic to the mesh type.
 
-    source_app_name: str
+    This is also used as the data type for storing service mesh policy information and thereby
+    defining a standard interface for charmed mesh managed policies.
+    """
+
     source_namespace: str
-    target_app_name: str
+    source_app_name: str
     target_namespace: str
+    target_app_name: Optional[str] = None
+    target_selector_labels: Optional[Dict[str, str]] = None
     target_service: Optional[str] = None
     target_type: Literal[PolicyTargetType.app, PolicyTargetType.unit] = PolicyTargetType.app
-    endpoints: List[Endpoint]
+    endpoints: List[Endpoint] = Field(default_factory=list)
+
+    @pydantic.model_validator(mode="after")
+    def _validate(self):
+        """Validate cross field constraints for the mesh policy."""
+        if self.target_type == PolicyTargetType.app:
+            self._validate_app_policy()
+        elif self.target_type == PolicyTargetType.unit:
+            self._validate_unit_policy()
+        return self
+
+    def _validate_app_policy(self) -> None:
+        """Validate app-targeted policy constraints."""
+        if not any([self.target_app_name, self.target_service]):
+            raise ValueError(
+                f"Bad policy configuration. Neither target_app_name nor target_service "
+                f"specified for MeshPolicy with target_type {self.target_type}"
+            )
+        if self.target_selector_labels:
+            raise ValueError(
+                f"Bad policy configuration. MeshPolicy with target_type {self.target_type} "
+                f"does not support target_selector_labels."
+            )
+
+    def _validate_unit_policy(self) -> None:
+        """Validate unit-targeted policy constraints."""
+        if self.target_app_name and self.target_selector_labels:
+            raise ValueError(
+                f"Bad policy configuration. MeshPolicy with target_type {self.target_type} "
+                f"cannot specify both target_app_name and target_selector_labels."
+            )
+        if self.target_service:
+            raise ValueError(
+                f"Bad policy configuration. MeshPolicy with target_type {self.target_type} "
+                f"does not support target_service."
+            )
+
+
+class ServiceMeshProviderAppData(pydantic.BaseModel):
+    """Data type for the application data provided by the provider side of the service-mesh interface."""
+
+    labels: Dict[str, str]
+    mesh_type: MeshType
 
 
 class CMRData(pydantic.BaseModel):
@@ -339,19 +419,16 @@ class ServiceMeshConsumer(Object):
 
         # Collect the remote data from any fully established cross_model_relation integrations
         # {remote application name: cmr relation data}
-        cmr_application_data = {
-            cmr.app.name: CMRData.model_validate(json.loads(cmr.data[cmr.app]["cmr_data"]))
-            for cmr in self._cmr_relations if "cmr_data" in cmr.data[cmr.app]
-        }
+        cmr_application_data = get_data_from_cmr_relation(self._cmr_relations)
 
         mesh_policies = build_mesh_policies(
             relation_mapping=self._charm.model.relations,
             target_app_name=self._charm.app.name,
             target_namespace=self._my_namespace(),
             policies=self._policies,
-            cmr_application_data=cmr_application_data
+            cmr_application_data=cmr_application_data,
         )
-        self._relation.data[self._charm.app]["policies"] = json.dumps(mesh_policies)
+        self._relation.data[self._charm.app]["policies"] = json.dumps([p.model_dump() for p in mesh_policies])
 
     def _my_namespace(self):
         """Return the namespace of the running charm."""
@@ -359,11 +436,32 @@ class ServiceMeshConsumer(Object):
         # should consider if there is a better way to do this.
         return self._charm.model.name
 
+    def _get_app_data(self) -> Optional[ServiceMeshProviderAppData]:
+        """Return the relation data for the remote application."""
+        if self._relation is None or not self._relation.app:
+            return None
+
+        raw_data = self._relation.data[self._relation.app]
+        if len(raw_data) == 0:
+            return None
+
+        raw_data = {k: json.loads(v) for k, v in raw_data.items()}
+        return ServiceMeshProviderAppData.model_validate(raw_data)
+
+
     def labels(self) -> dict:
         """Labels required for a pod to join the mesh."""
-        if self._relation is None or "labels" not in self._relation.data[self._relation.app]:
+        app_data = self._get_app_data()
+        if app_data is None:
             return {}
-        return json.loads(self._relation.data[self._relation.app]["labels"])
+        return app_data.labels
+
+    def mesh_type(self) -> Optional[MeshType]:
+        """Return the type of the service mesh."""
+        app_data = self._get_app_data()
+        if app_data is None:
+            return None
+        return app_data.mesh_type
 
     def _on_mesh_broken(self, _event):
         if not self._charm.unit.is_leader():
@@ -410,40 +508,57 @@ class ServiceMeshProvider(Object):
     """Provide a service mesh to applications."""
 
     def __init__(
-        self, charm: CharmBase, labels: Dict[str, str], mesh_relation_name: str = "service-mesh"
+        self,
+        charm: CharmBase,
+        labels: Dict[str, str],
+        mesh_type: MeshType,
+        mesh_relation_name: str = "service-mesh",
     ):
         """Class used to provide information needed to join the service mesh.
 
         Args:
             charm: The charm instantiating this object.
+            labels: The labels which related applications need to apply to use the mesh.
+            mesh_type: The type of this service mesh.
             mesh_relation_name: The relation name as defined in metadata.yaml or charmcraft.yaml
                 for the relation which uses the service_mesh interface.
-            labels: The labels which related applications need to apply to use the mesh.
         """
         super().__init__(charm, mesh_relation_name)
         self._charm = charm
         self._relation_name = mesh_relation_name
         self._labels = labels
+        self._mesh_type = mesh_type
         self.framework.observe(
             self._charm.on[mesh_relation_name].relation_created, self._relation_created
         )
+        self.framework.observe(
+            self._charm.on.config_changed, self._on_config_changed
+        )
 
     def _relation_created(self, _event):
+        self.update_relations()
+
+    def _on_config_changed(self, _event):
         self.update_relations()
 
     def update_relations(self):
         """Update all relations with the labels needed to use the mesh."""
         # Only the leader unit can update the application data bag
         if self._charm.unit.is_leader():
-            rel_data = json.dumps(self._labels)
+            data = ServiceMeshProviderAppData(
+                labels=self._labels,
+                mesh_type=self._mesh_type
+            ).model_dump(mode="json", by_alias=True, exclude_defaults=True, round_trip=True)
+            # Flatten any nested objects, since relation databags are str:str mappings
+            data = {k: json.dumps(v) for k, v in data.items()}
             for relation in self._charm.model.relations[self._relation_name]:
-                relation.data[self._charm.app]["labels"] = rel_data
+                relation.data[self._charm.app].update(data)
 
     def mesh_info(self) -> List[MeshPolicy]:
         """Return the relation data that defines Policies requested by the related applications."""
         mesh_info = []
         for relation in self._charm.model.relations[self._relation_name]:
-            policies_data = json.loads(relation.data[relation.app]["policies"])
+            policies_data = json.loads(relation.data[relation.app].get("policies", "[]"))
             policies = [MeshPolicy.model_validate(policy) for policy in policies_data]
             mesh_info.extend(policies)
         return mesh_info
@@ -454,20 +569,25 @@ def build_mesh_policies(
         target_app_name: str,
         target_namespace: str,
         policies: List[Union[Policy, AppPolicy, UnitPolicy]],
-        cmr_application_data: Dict[str, CMRData]
+        cmr_application_data: Optional[Dict[str, CMRData]] = None,
 ) -> List[MeshPolicy]:
     """Generate MeshPolicy that implement the given policies for the currently related applications.
 
     Args:
-        relation_mapping: Charm's RelatioMapping object, for example self.model.relations.
+        relation_mapping: Charm's RelationMapping object, for example self.model.relations.
         target_app_name: The name of the target application, for example self.app.name.
         target_namespace: The namespace of the target application, for example self.model.name.
         policies: List of AppPolicy, or UnitPolicy objects defining the access rules.
         cmr_application_data: Data for cross-model relations, mapping app names to CMRData.
     """
+    if not cmr_application_data:
+        cmr_application_data = {}
+
     mesh_policies = []
     for policy in policies:
+        logger.debug(f"Processing policy for relation endpoint '{policy.relation}'.")
         for relation in relation_mapping[policy.relation]:
+            logger.debug(f"Processing policy for related application '{relation.app.name}'.")
             if relation.app.name in cmr_application_data:
                 logger.debug(f"Found cross model relation: {relation.name}. Creating policy.")
                 source_app_name = cmr_application_data[relation.app.name].app_name
@@ -480,10 +600,10 @@ def build_mesh_policies(
             if isinstance(policy, UnitPolicy):
                 mesh_policies.append(
                     MeshPolicy(
-                        source_app_name=source_app_name,
                         source_namespace=source_namespace,
-                        target_app_name=target_app_name,
+                        source_app_name=source_app_name,
                         target_namespace=target_namespace,
+                        target_app_name=target_app_name,
                         target_service=None,
                         target_type=PolicyTargetType.unit,
                         endpoints=[
@@ -493,20 +613,21 @@ def build_mesh_policies(
                         ]
                         if policy.ports
                         else [],
-                    ).model_dump()
+                    )
                 )
             else:
                mesh_policies.append(
                     MeshPolicy(
-                        source_app_name=source_app_name,
                         source_namespace=source_namespace,
-                        target_app_name=target_app_name,
+                        source_app_name=source_app_name,
                         target_namespace=target_namespace,
+                        target_app_name=target_app_name,
                         target_service=policy.service,
                         target_type=PolicyTargetType.app,
                         endpoints=policy.endpoints,
-                    ).model_dump()
+                    )
                 )
+
     return mesh_policies
 
 
@@ -532,10 +653,7 @@ def reconcile_charm_labels(client: Client, app_name: str, namespace: str,  label
         labels: A dictionary of labels to set on the Charm's Kubernetes objects. Any labels that were previously created
                 by this method but omitted in `labels` now will be removed from the Kubernetes objects.
     """
-    patch_labels = {}
-    patch_labels.update(labels)
-    stateful_set = client.get(res=StatefulSet, name=app_name)
-    service = client.get(res=Service, name=app_name)
+    patch_labels: Dict[str, Optional[str]] = dict(labels)
     try:
         config_map = client.get(ConfigMap, label_configmap_name)
     except httpx.HTTPStatusError as e:
@@ -549,19 +667,22 @@ def reconcile_charm_labels(client: Client, app_name: str, namespace: str,  label
             if label not in patch_labels:
                 # The label was previously set. Setting it to None will delete it.
                 patch_labels[label] = None
-    if stateful_set.spec:
-        stateful_set.spec.template.metadata.labels.update(patch_labels)  # type: ignore
-    if service.metadata:
-        service.metadata.labels = service.metadata.labels or {}
-        service.metadata.labels.update(patch_labels)
+
+    # Patch just the labels instead of the entire resource defintion.
+    # This minimal approach reduces the chance of 409 conflicts when other actors are modifying the resources.
+    # Retrying here is a bad idea as we WANT to get a 409 when someone else patches OUR labels. We shouldn't mask that.
+    client.patch(res=StatefulSet, name=app_name, obj={
+        "spec": {"template": {"metadata": {"labels": patch_labels}}}
+    })
+    client.patch(res=Service, name=app_name, obj={
+        "metadata": {"labels": patch_labels}
+    })
 
     # Store our actively managed labels in a ConfigMap so next call we know which we might need to delete.
     # This should not include any labels that are nulled out as they're now out of scope.
     config_map_labels = {k: v for k, v in patch_labels.items() if v is not None}
     config_map.data = {"labels": json.dumps(config_map_labels)}
     client.patch(res=ConfigMap, name=label_configmap_name, obj=config_map)
-    client.patch(res=StatefulSet, name=app_name, obj=stateful_set)
-    client.patch(res=Service, name=app_name, obj=service)
 
 
 def _init_label_configmap(client, name, namespace) -> ConfigMap:
@@ -575,3 +696,487 @@ def _init_label_configmap(client, name, namespace) -> ConfigMap:
     )
     client.create(obj=obj)
     return obj
+
+
+########################################
+#  MESH NETWORK POLICY MANAGER HELPERS #
+########################################
+def _get_peer_identity_for_juju_application(app_name, namespace):
+    """Return a Juju application's peer identity.
+
+    Format returned is defined by `principals` in
+    [this reference](https://istio.io/latest/docs/reference/config/security/authorization-policy/#Source):
+
+    This function relies on the Juju convention that each application gets a ServiceAccount of the same name in the same
+    namespace.
+    """
+    service_account = app_name
+    return _get_peer_identity_for_service_account(service_account, namespace)
+
+
+def _get_peer_identity_for_service_account(service_account, namespace):
+    """Return a ServiceAccount's peer identity.
+
+    Format returned is defined by `principals` in
+    [this reference](https://istio.io/latest/docs/reference/config/security/authorization-policy/#Source):
+        "cluster.local/ns/{namespace}/sa/{service_account}"
+    """
+    return f"cluster.local/ns/{namespace}/sa/{service_account}"
+
+
+def _hash_pydantic_model(model: pydantic.BaseModel) -> str:
+    """Hash a pydantic BaseModel object.
+
+    This is a simple hashing of the json model dump of the pydantic model.  Items that are excluded from this dump
+    will not affect the output.
+    """
+
+    def _stable_hash(data):
+        return hashlib.sha256(str(data).encode()).hexdigest()
+
+    # Note: This hash will be affected by changes in how pydantic stringifies data, so if they change things our hash
+    # will change too.  If that proves an issue, we could implement something more controlled here.
+    return _stable_hash(model)
+
+
+def _generate_network_policy_name(app_name: str, model_name: str, mesh_policy: MeshPolicy) -> str:
+        """Generate a unique name for the network policy resource, suffixing a hash of the MeshPolicy to avoid collisions.
+
+        The name has the following general format:
+            {app_name}-{model_name}-policy-{source_app_name}-{source_namespace}-{target_app_name/target_service/custom-selector}-{hash}
+        but source_app_name and the name of the target will be truncated if the total name exceeds Kubernetes's limit of 253
+        characters.
+        """
+        # omit target_app_namespace from the name here because that will be the namespace the policy is generated in, so
+        # adding it here is redundant
+        target = mesh_policy.target_app_name or mesh_policy.target_service or "custom-selector"
+
+        name = "-".join(
+            [
+                app_name,
+                model_name,
+                "policy",
+                mesh_policy.source_app_name,
+                mesh_policy.source_namespace,
+                target,
+                _hash_pydantic_model(mesh_policy)[:8],
+            ]
+        )
+        if len(name) > 253:
+            # Truncate the name to fit within Kubernetes's 253-character limit
+            # juju app names and models must be <= 63 characters each and we have ~20 characters of static text, so
+            # if name is too long just take the first 30 characters of source_app_name, source_namespace, and
+            # target_app_name to be safe.
+            name = "-".join(
+                [
+                    app_name,
+                    model_name,
+                    "policy",
+                    mesh_policy.source_app_name[:30],
+                    mesh_policy.source_namespace[:30],
+                    target[:30],
+                    _hash_pydantic_model(mesh_policy)[:8],
+                ]
+            )
+        return name
+
+
+def _build_policy_resources_istio(app_name: str, model_name: str, policies: List[MeshPolicy]) -> Union[LightkubeResourcesList, List[None]]:
+        """Build the required authorization policy resources for istio service mesh."""
+        authorization_policies = [None] * len(policies)
+        for i, policy in enumerate(policies):
+            # L4 policy created for target Juju units (workloads)
+            if policy.target_type == PolicyTargetType.unit:
+                # if the mesh policy of type unit contain any of the L7 attributes, warn and don't create the policy
+                valid_unit_policy = not any(
+                    endpoint.methods or endpoint.paths or endpoint.hosts
+                    for endpoint in policy.endpoints
+                )
+                if not valid_unit_policy:
+                    logger.error(
+                        f"UnitPolicy requested between {policy.source_app_name} and {policy.target_app_name} is not created as it contains some disallowed policy attributes."
+                        "UnitPolicy for Istio service mesh cannot contain paths, methods or hosts"
+                    )
+                    continue
+
+                # Build match labels based on policy definition
+                workload_selector = None
+                if policy.target_app_name:
+                    workload_selector = WorkloadSelector(
+                        matchLabels={
+                            "app.kubernetes.io/name": policy.target_app_name,
+                        }
+                    )
+                if policy.target_selector_labels:
+                    workload_selector = WorkloadSelector(
+                        matchLabels=policy.target_selector_labels
+                    )
+
+                authorization_policies[i] = AuthorizationPolicy(  # type: ignore[assignment]
+                    metadata=ObjectMeta(
+                        name=_generate_network_policy_name(app_name, model_name, policy),
+                        namespace=policy.target_namespace,
+                    ),
+                    spec=AuthorizationPolicySpec(
+                        selector=workload_selector,
+                        rules=[
+                            Rule(
+                                from_=[  # type: ignore # this is accessible via an alias
+                                    From(
+                                        source=Source(
+                                            principals=[
+                                                _get_peer_identity_for_juju_application(
+                                                    policy.source_app_name, policy.source_namespace
+                                                )
+                                            ]
+                                        )
+                                    )
+                                ],
+                                to=[
+                                    To(
+                                        operation=Operation(
+                                            # TODO: Make these ports strings instead of ints in endpoint?
+                                            ports=[str(p) for p in endpoint.ports]
+                                            if endpoint.ports
+                                            else [],
+                                        )
+                                    )
+                                    for endpoint in policy.endpoints
+                                ],
+                            ),
+                        ],
+                    ).model_dump(by_alias=True, exclude_unset=True, exclude_none=True),
+                )
+
+            # L7 policy created for target Juju applications (services)
+            elif policy.target_type == PolicyTargetType.app:
+                target_service = policy.target_service or policy.target_app_name
+                if policy.target_service is None:
+                    logger.info(
+                        f"Got policy for application '{policy.target_app_name}' that has no target_service. "
+                        f"Defaulting to application name."
+                    )
+                if all([policy.target_service, policy.target_app_name]):
+                    logger.info(
+                        f"Got policy for application '{policy.target_app_name}' that has both target_service and target_app_name. "
+                        f"Using {target_service} for policy target definition."
+                    )
+
+                authorization_policies[i] = AuthorizationPolicy(  # type: ignore[assignment]
+                    metadata=ObjectMeta(
+                        name=_generate_network_policy_name(app_name, model_name, policy),
+                        namespace=policy.target_namespace,
+                    ),
+                    spec=AuthorizationPolicySpec(
+                        targetRefs=[
+                            PolicyTargetReference(
+                                kind="Service",
+                                group="",
+                                name=target_service,  # type: ignore
+                            )
+                        ],
+                        rules=[
+                            Rule(
+                                from_=[  # type: ignore # this is accessible via an alias
+                                    From(
+                                        source=Source(
+                                            principals=[
+                                                _get_peer_identity_for_juju_application(
+                                                    policy.source_app_name, policy.source_namespace
+                                                )
+                                            ]
+                                        )
+                                    )
+                                ],
+                                to=[
+                                    To(
+                                        operation=Operation(
+                                            # TODO: Make these ports strings instead of ints in endpoint?
+                                            ports=[str(p) for p in endpoint.ports]
+                                            if endpoint.ports
+                                            else [],
+                                            hosts=endpoint.hosts,
+                                            methods=endpoint.methods,  # type: ignore
+                                            paths=endpoint.paths,
+                                        )
+                                    )
+                                    for endpoint in policy.endpoints
+                                ],
+                            )
+                        ],
+                        # by_alias=True because the model includes an alias for the `from` field
+                        # exclude_unset=True because unset fields will be treated as their default values in Kubernetes
+                        # exclude_none=True because null values in this data always mean the Kubernetes default
+                    ).model_dump(by_alias=True, exclude_unset=True, exclude_none=True),
+                )
+
+            else:
+                raise ValueError("Failed to build requested istio authorization policy. Unknown target_type for policy.")
+
+        return authorization_policies
+
+
+class PolicyResourceManager():
+    """A Mesh agnostic policy resource manager that manages manifests of different policy manifests in Kubernetes.
+
+    This can be used by the charms to create and manage their own policy resources under circumstances like but not limited to
+        i.   Using Canonical Service Mesh in a non-managed model_name
+        ii.  Managing highly custom policies that cannot be defined in the ServiceMeshConsumer
+        iii. Managing authorization policies between charms that are not related to the charmed service mesh's beacon.
+
+    The PolicyResourceManager provides a reconcile method that can be used in the charm's own reconciler methods for reconciling
+    the policies managed by the charm to the desired state.
+
+    Example:
+    ```python
+    from charms.istio_beacon_k8s.v0.service_mesh import (
+        MeshPolicy,
+        PolicyTargetType,
+        Endpoint,
+        PolicyResourceManager,
+        MeshType,
+    )
+
+    class MyCharm(CharmBase):
+
+        def __init__(self, *args):
+            super().__init__(*args)
+            self._mesh = ServiceMeshConsumer(self)
+
+            self.observe_everything()
+
+        def _get_policy_manager(self):
+            prm = PolicyResourceManager(
+                charm=self,
+                lightkube_client=self.lightkube_client,
+                labels={
+                    "label-key": "label-value-that-helps-identify-this-resource",
+                },
+            )
+            return prm
+
+        def _get_policies_i_manage(self):
+            policies=[
+                # policy to allow juju_app_a in juju_app_a_model to talk to juju_app_b in juju_app_b_model with a service
+                # name juju_app_b_service through its service address in ports 8080 and 443 to GET /foo and /bar paths.
+                MeshPolicy[
+                    source_namespace="juju_app_a_model",
+                    source_app_name="juju_app_a",
+                    target_namespace="juju_app_b_model",
+                    target_app_name="juju_app_b",
+                    target_service="juju_app_b_service",
+                    target_type=PolicyTargetType.app,
+                    endpoints=[
+                        Endpoint(
+                            ports=[8080, 443],
+                            methods=[Method.get],
+                            paths=["/foo", "/bar"]
+                        )
+                    ]
+                ],
+                # policy to allow juju_app_a in juju_app_a_model to talk to juju_app_c in juju_app_c_model with a service
+                # name same as the app name through its service address in ports 8080 and 443 to GET /foo.
+                MeshPolicy[
+                    source_namespace="juju_app_a_model",
+                    source_app_name="juju_app_a",
+                    target_namespace="juju_app_c_model",
+                    target_app_name="juju_app_c",
+                    target_type=PolicyTargetType.app,
+                    endpoints=[
+                        Endpoint(
+                            ports=[8080, 443],
+                            methods=[Method.get],
+                            paths=["/foo"]
+                        )
+                    ]
+                ],
+                # policy to allow juju_app_a in juju_app_a_model to talk to juju_app_d in juju_app_d_model with a service
+                # through its pod address in ports 8080. For unit type policies paths and methods restrictions don't apply.
+                MeshPolicy[
+                    source_namespace="juju_app_a_model",
+                    source_app_name="juju_app_a",
+                    target_namespace="juju_app_d_model",
+                    target_app_name="juju_app_d",
+                    target_type=PolicyTargetType.unit,
+                    endpoints=[
+                        Endpoint(
+                            ports=[8080]
+                        )
+                    ]
+                ]
+            ]
+            return policies
+
+        def _on_remove(self):
+            prm = self._get_policy_manager()
+            prm.delete()
+
+        def _reconcile(self):
+            prm = self._get_policy_manager()
+            policies = self._get_policies_i_manage()
+            prm.reconcile(policies, MeshType.istio)
+    ````
+    Args:
+        charm (ops.CharmBase): The charm instantiating this object.
+        lightkube_client (lightkube.Client): Lightkube Client to use for all k8s operations.
+                                             This Client must be instantiated with a
+                                             field_manager, otherwise it cannot be used to
+                                             .apply() resources because the kubernetes server
+                                             side apply patch method requires it. A good option
+                                             for this is to use the application name (eg:
+                                             `self.model.app.name` or
+                                             `self.model.app.name +'_' self.model.name`).
+        mesh_type (charms.istio_beacon_k8s.v0.service_mesh.MeshType): The type of service mesh for which
+                                                                      the policy resources are to be generated.
+                                                                      (eg: MeshType.istio)
+        labels (dict): A dict of labels to use as a label selector for all resources
+                           managed by this KRM.  These will be added to any applied resources at
+                           .apply() time and will be used to find existing resources in
+                           .get_deployed_resources().
+                           Recommended input for this is:
+                             labels = {
+                              'app.kubernetes.io/name': f"{self.model.app.name}-{self.model.name}",
+                              'kubernetes-resource-handler-scope': 'some-user-chosen-scope'
+                             }
+                           See `get_default_labels` for a helper to generate this label dict.
+        logger (logging.Logger): (Optional) A logger to use for logging (so that log messages
+                                 emitted here will appear under the caller's log namespace).
+                                 If not provided, a default logger will be created.
+    """
+    def __init__(
+        self,
+        charm: CharmBase,
+        lightkube_client: Client,
+        labels: Optional[Dict] = None,
+        logger: Optional[logging.Logger] = None,
+    ):
+        self._app_name = charm.app.name
+        self._model_name = charm.model.name
+        resource_types = self._get_all_supported_policy_resource_types()
+
+        if logger is None:
+            self.log = logging.getLogger(__name__)
+        else:
+            self.log = logger
+        self._krm = KubernetesResourceManager(
+            labels=labels,
+            resource_types=resource_types,  # type: ignore
+            lightkube_client=lightkube_client,
+            logger=self.log,
+        )
+
+    @staticmethod
+    def _get_all_supported_policy_resource_types() -> LightkubeResourceTypesSet:
+        """Return all the resource types supported by the PRM class."""
+        all_types: Set[Type] = set()
+        for resource_types in POLICY_RESOURCE_TYPES.values():
+            all_types.update(resource_types)
+        return all_types
+
+    @staticmethod
+    def _get_policy_resource_builder(mesh_type: MeshType):
+        if mesh_type == MeshType.istio:
+            return _build_policy_resources_istio
+        raise ValueError(f"PolicyResourceManager instantiated with an unknown mesh type: {mesh_type}. Check Canonical Service Mesh documentation for currently supported mesh types.")
+
+    def _build_policy_resources(self, policies: List[MeshPolicy], mesh_type: MeshType) -> LightkubeResourcesList:
+        """Build the Lightkube resources for the managed policies."""
+        policy_resource_builder = self._get_policy_resource_builder(mesh_type)
+        return policy_resource_builder(self._app_name, self._model_name, policies)  # type: ignore
+
+    def _validate_raw_policies(self, raw_policies: List[AuthorizationPolicy]) -> None:  # type: ignore[type-arg]
+        """Validate that raw_policies contain only supported resource types.
+
+        Raises:
+            TypeError: If a raw_policy is not of a supported type.
+        """
+        supported_types = self._get_all_supported_policy_resource_types()
+        if not supported_types:
+            raise RuntimeError("No supported policy resource types found in PolicyResourceManager.")
+        for policy in raw_policies:
+            if type(policy) not in supported_types:
+                self.log.error(
+                    f"raw_policy of type '{type(policy).__name__}' is not a supported policy resource type."
+                )
+                raise TypeError(
+                    f"raw_policy of type '{type(policy).__name__}' is not a supported policy resource type. "
+                    f"Supported types: {[t.__name__ for t in supported_types]}"
+                )
+
+    def reconcile(
+        self,
+        policies: List[MeshPolicy],
+        mesh_type: MeshType,
+        raw_policies: Optional[List[AuthorizationPolicy]] = None,  # type: ignore[type-arg]
+        force: bool = True,
+        ignore_missing: bool = True,
+    ) -> None:
+        """Reconcile the given policies, removing, updating, or creating objects as required.
+
+        The MeshPolicy objects are first converted into manifests for Kubernetes policy resources that the
+        service mesh can understand. eg: AuthorizationPolicy resources for Istio service mesh.
+
+        This method will:
+        * create a list of policy resources containing a policy resource for every provided MeshPolicy object
+        * optionally merge with raw_policies (pre-built policy resources provided by the caller)
+        * get all resources currently deployed that match the label selector in self.labels
+        * compare the existing resources to the desired resources provided, deleting any resources
+          that exist but are not in the desired resource list
+        * call krm.apply() to create any new resources and update any remaining existing ones to the
+          desired state
+
+        Args:
+            policies: A list of MeshPolicy objects that define the required behaviour of the policy resources.
+            mesh_type: The type of service mesh the charm is connected to. This information can be obtained from ServiceMeshConsumer.
+            raw_policies: *(optional)* Pre-built policy resources to merge with the built policies.
+                          These must be of supported types (e.g., AuthorizationPolicy for Istio).
+            force: *(optional)* Passed to self.apply().  This will force apply over any resources
+                   marked as managed by another field manager.
+            ignore_missing: *(optional)* Avoid raising 404 errors on deletion (defaults to True)
+
+        Raises:
+            TypeError: If raw_policies contains resources of unsupported types.
+        """
+        if raw_policies:
+            self._validate_raw_policies(raw_policies)
+
+        all_resources: List = list(self._build_policy_resources(policies, mesh_type)) if policies else []
+        if raw_policies:
+            all_resources.extend(raw_policies)
+
+        if not all_resources:
+            self.delete(ignore_missing=ignore_missing)
+            return
+
+        self._krm.reconcile(all_resources, force=force, ignore_missing=ignore_missing)
+
+    def delete(self, ignore_missing=True):
+        """Delete all the policy resources handled by this manager.
+
+        Requires that self.labels and self.resource_types be set.
+
+        Args:
+            ignore_missing: *(optional)* Avoid raising 404 errors on deletion (defaults to True)
+        """
+        try:
+            self._krm.delete(ignore_missing=ignore_missing)
+        # FIXME: this is a workaround and should be handled by the upstream krm. Issue exists: https://github.com/canonical/lightkube-extensions/issues/4
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404 and ignore_missing:
+                # CRD doesn't exist, nothing to delete (only when ignore_missing=True)
+                self.log.info("CRD not found, skipping deletion")
+                return
+            raise
+
+
+def get_data_from_cmr_relation(cmr_relations) -> Dict[str, CMRData]:
+    """Return a dictionary of CMRData from the established cross-model relations."""
+    cmr_data = {}
+    for cmr in cmr_relations:
+        if "cmr_data" in cmr.data[cmr.app]:
+            try:
+                cmr_data[cmr.app.name] = CMRData.model_validate(json.loads(cmr.data[cmr.app]["cmr_data"]))
+            except pydantic.ValidationError as e:
+                logger.error(f"Invalid CMR data for {cmr.app.name}: {e}")
+                continue
+    return cmr_data

--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -79,7 +79,6 @@ and three optional arguments.
               external_url = urlparse(self._external_url)
               self.loki_provider = LokiPushApiProvider(
                   self,
-                  address=external_url.hostname or self.hostname,
                   port=external_url.port or 80,
                   scheme=external_url.scheme,
                   path=f"{external_url.path}/loki/api/v1/push",
@@ -96,6 +95,7 @@ The `LokiPushApiProvider` object has several responsibilities:
 
 1. Set the URL of the Loki Push API in the relation application data bag; the URL
    must be unique to all instances (e.g. using a load balancer).
+   The default URL is the FQDN, but this can be overridden by calling `update_endpoint()`.
 
 2. Set the Promtail binary URL (`promtail_binary_zip_url`) so clients that use
    `LogProxyConsumer` object could download and configure it.
@@ -190,10 +190,7 @@ The `LokiPushApiConsumer` constructor requires two things:
   with its clients. If provided, this relation name must match a required
   relation in metadata.yaml with the `loki_push_api` interface.
 
-  This argument is not required if your metadata.yaml has precisely one
-  required relation in metadata.yaml with the `loki_push_api` interface, as the
-  lib will automatically resolve the relation name inspecting the using the
-  meta information of the charm
+  If not provided, the relation name defaults to `logging`.
 
 Any time the relation between a Loki provider charm and a Loki consumer charm is
 established, a `LokiPushApiEndpointJoined` event is fired. In the consumer side
@@ -409,7 +406,7 @@ named `loki_alert_rules`.
 
 This directory must reside at the top level in the `src` folder of the
 consumer charm. Each file in this directory is assumed to be a single alert rule
-in YAML format. The file name must have the `.rule` extension.
+in YAML format. The file name must have one of the following extensions: `.yaml`, `.yml`, `.rule`, or `.rules`.
 The format of this alert rule conforms to the
 [Loki docs](https://grafana.com/docs/loki/latest/rules/#alerting-rules).
 
@@ -501,26 +498,27 @@ class MyCharm(...):
 Do this, and all charm logs will be forwarded to Loki as soon as a relation is formed.
 """
 
+import copy
 import json
 import logging
 import os
 import platform
 import re
 import socket
-import subprocess
-import tempfile
-import typing
+import warnings
 from copy import deepcopy
 from gzip import GzipFile
 from hashlib import sha256
 from io import BytesIO
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union, cast
 from urllib import request
 from urllib.error import URLError
 
 import yaml
-from cosl import JujuTopology
+from cosl import CosTool, JujuTopology
+from cosl.rules import AlertRules
+from cosl.types import OfficialRuleFileFormat
 from ops.charm import (
     CharmBase,
     HookEvent,
@@ -546,7 +544,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 16
+LIBPATCH = 25
 
 PYDEPS = ["cosl"]
 
@@ -720,273 +718,6 @@ class InvalidAlertRulePathError(Exception):
         super().__init__(self.message)
 
 
-def _is_official_alert_rule_format(rules_dict: dict) -> bool:
-    """Are alert rules in the upstream format as supported by Loki.
-
-    Alert rules in dictionary format are in "official" form if they
-    contain a "groups" key, since this implies they contain a list of
-    alert rule groups.
-
-    Args:
-        rules_dict: a set of alert rules in Python dictionary format
-
-    Returns:
-        True if alert rules are in official Loki file format.
-    """
-    return "groups" in rules_dict
-
-
-def _is_single_alert_rule_format(rules_dict: dict) -> bool:
-    """Are alert rules in single rule format.
-
-    The Loki charm library supports reading of alert rules in a
-    custom format that consists of a single alert rule per file. This
-    does not conform to the official Loki alert rule file format
-    which requires that each alert rules file consists of a list of
-    alert rule groups and each group consists of a list of alert
-    rules.
-
-    Alert rules in dictionary form are considered to be in single rule
-    format if in the least it contains two keys corresponding to the
-    alert rule name and alert expression.
-
-    Returns:
-        True if alert rule is in single rule file format.
-    """
-    # one alert rule per file
-    return set(rules_dict) >= {"alert", "expr"}
-
-
-class AlertRules:
-    """Utility class for amalgamating Loki alert rule files and injecting juju topology.
-
-    An `AlertRules` object supports aggregating alert rules from files and directories in both
-    official and single rule file formats using the `add_path()` method. All the alert rules
-    read are annotated with Juju topology labels and amalgamated into a single data structure
-    in the form of a Python dictionary using the `as_dict()` method. Such a dictionary can be
-    easily dumped into JSON format and exchanged over relation data. The dictionary can also
-    be dumped into YAML format and written directly into an alert rules file that is read by
-    Loki. Note that multiple `AlertRules` objects must not be written into the same file,
-    since Loki allows only a single list of alert rule groups per alert rules file.
-
-    The official Loki format is a YAML file conforming to the Loki documentation
-    (https://grafana.com/docs/loki/latest/api/#list-rule-groups).
-    The custom single rule format is a subsection of the official YAML, having a single alert
-    rule, effectively "one alert per file".
-    """
-
-    # This class uses the following terminology for the various parts of a rule file:
-    # - alert rules file: the entire groups[] yaml, including the "groups:" key.
-    # - alert groups (plural): the list of groups[] (a list, i.e. no "groups:" key) - it is a list
-    #   of dictionaries that have the "name" and "rules" keys.
-    # - alert group (singular): a single dictionary that has the "name" and "rules" keys.
-    # - alert rules (plural): all the alerts in a given alert group - a list of dictionaries with
-    #   the "alert" and "expr" keys.
-    # - alert rule (singular): a single dictionary that has the "alert" and "expr" keys.
-
-    def __init__(self, topology: Optional[JujuTopology] = None):
-        """Build and alert rule object.
-
-        Args:
-            topology: a `JujuTopology` instance that is used to annotate all alert rules.
-        """
-        self.topology = topology
-        self.tool = CosTool(None)
-        self.alert_groups = []  # type: List[dict]
-
-    def _from_file(self, root_path: Path, file_path: Path) -> List[dict]:
-        """Read a rules file from path, injecting juju topology.
-
-        Args:
-            root_path: full path to the root rules folder (used only for generating group name)
-            file_path: full path to a *.rule file.
-
-        Returns:
-            A list of dictionaries representing the rules file, if file is valid (the structure is
-            formed by `yaml.safe_load` of the file); an empty list otherwise.
-        """
-        with file_path.open() as rf:
-            # Load a list of rules from file then add labels and filters
-            try:
-                rule_file = yaml.safe_load(rf) or {}
-
-            except Exception as e:
-                logger.error("Failed to read alert rules from %s: %s", file_path.name, e)
-                return []
-
-            if _is_official_alert_rule_format(rule_file):
-                alert_groups = rule_file["groups"]
-            elif _is_single_alert_rule_format(rule_file):
-                # convert to list of alert groups
-                # group name is made up from the file name
-                alert_groups = [{"name": file_path.stem, "rules": [rule_file]}]
-            else:
-                # invalid/unsupported
-                reason = "file is empty" if not rule_file else "unexpected file structure"
-                logger.error("Invalid rules file (%s): %s", reason, file_path.name)
-                return []
-
-            # update rules with additional metadata
-            for alert_group in alert_groups:
-                # update group name with topology and sub-path
-                alert_group["name"] = self._group_name(
-                    str(root_path),
-                    str(file_path),
-                    alert_group["name"],
-                )
-
-                # add "juju_" topology labels
-                for alert_rule in alert_group["rules"]:
-                    if "labels" not in alert_rule:
-                        alert_rule["labels"] = {}
-
-                    if self.topology:
-                        # only insert labels that do not already exist
-                        for label, val in self.topology.label_matcher_dict.items():
-                            if label not in alert_rule["labels"]:
-                                alert_rule["labels"][label] = val
-
-                        # insert juju topology filters into a prometheus alert rule
-                        # logql doesn't like empty matchers, so add a job matcher which hits
-                        # any string as a "wildcard" which the topology labels will
-                        # filter down
-                        alert_rule["expr"] = self.tool.inject_label_matchers(
-                            re.sub(r"%%juju_topology%%", r'job=~".+"', alert_rule["expr"]),
-                            self.topology.label_matcher_dict,
-                        )
-
-            return alert_groups
-
-    def _group_name(
-        self,
-        root_path: typing.Union[Path, str],
-        file_path: typing.Union[Path, str],
-        group_name: str,
-    ) -> str:
-        """Generate group name from path and topology.
-
-        The group name is made up of the relative path between the root dir_path, the file path,
-        and topology identifier.
-
-        Args:
-            root_path: path to the root rules dir.
-            file_path: path to rule file.
-            group_name: original group name to keep as part of the new augmented group name
-
-        Returns:
-            New group name, augmented by juju topology and relative path.
-        """
-        file_path = Path(file_path) if not isinstance(file_path, Path) else file_path
-        root_path = Path(root_path) if not isinstance(root_path, Path) else root_path
-        rel_path = file_path.parent.relative_to(root_path.as_posix())
-
-        # We should account for both absolute paths and Windows paths. Convert it to a POSIX
-        # string, strip off any leading /, then join it
-
-        path_str = ""
-        if not rel_path == Path("."):
-            # Get rid of leading / and optionally drive letters so they don't muck up
-            # the template later, since Path.parts returns them. The 'if relpath.is_absolute ...'
-            # isn't even needed since re.sub doesn't throw exceptions if it doesn't match, so it's
-            # optional, but it makes it clear what we're doing.
-
-            # Note that Path doesn't actually care whether the path is valid just to instantiate
-            # the object, so we can happily strip that stuff out to make templating nicer
-            rel_path = Path(
-                re.sub(r"^([A-Za-z]+:)?/", "", rel_path.as_posix())
-                if rel_path.is_absolute()
-                else str(rel_path)
-            )
-
-            # Get rid of relative path characters in the middle which both os.path and pathlib
-            # leave hanging around. We could use path.resolve(), but that would lead to very
-            # long template strings when rules come from pods and/or other deeply nested charm
-            # paths
-            path_str = "_".join(filter(lambda x: x not in ["..", "/"], rel_path.parts))
-
-        # Generate group name:
-        #  - name, from juju topology
-        #  - suffix, from the relative path of the rule file;
-        group_name_parts = [self.topology.identifier] if self.topology else []
-        group_name_parts.extend([path_str, group_name, "alerts"])
-        # filter to remove empty strings
-        return "_".join(filter(lambda x: x, group_name_parts))
-
-    @classmethod
-    def _multi_suffix_glob(
-        cls, dir_path: Path, suffixes: List[str], recursive: bool = True
-    ) -> list:
-        """Helper function for getting all files in a directory that have a matching suffix.
-
-        Args:
-            dir_path: path to the directory to glob from.
-            suffixes: list of suffixes to include in the glob (items should begin with a period).
-            recursive: a flag indicating whether a glob is recursive (nested) or not.
-
-        Returns:
-            List of files in `dir_path` that have one of the suffixes specified in `suffixes`.
-        """
-        all_files_in_dir = dir_path.glob("**/*" if recursive else "*")
-        return list(filter(lambda f: f.is_file() and f.suffix in suffixes, all_files_in_dir))
-
-    def _from_dir(self, dir_path: Path, recursive: bool) -> List[dict]:
-        """Read all rule files in a directory.
-
-        All rules from files for the same directory are loaded into a single
-        group. The generated name of this group includes juju topology.
-        By default, only the top directory is scanned; for nested scanning, pass `recursive=True`.
-
-        Args:
-            dir_path: directory containing *.rule files (alert rules without groups).
-            recursive: flag indicating whether to scan for rule files recursively.
-
-        Returns:
-            a list of dictionaries representing prometheus alert rule groups, each dictionary
-            representing an alert group (structure determined by `yaml.safe_load`).
-        """
-        alert_groups = []  # type: List[dict]
-
-        # Gather all alerts into a list of groups
-        for file_path in self._multi_suffix_glob(dir_path, [".rule", ".rules"], recursive):
-            alert_groups_from_file = self._from_file(dir_path, file_path)
-            if alert_groups_from_file:
-                logger.debug("Reading alert rule from %s", file_path)
-                alert_groups.extend(alert_groups_from_file)
-
-        return alert_groups
-
-    def add_path(self, path_str: str, *, recursive: bool = False):
-        """Add rules from a dir path.
-
-        All rules from files are aggregated into a data structure representing a single rule file.
-        All group names are augmented with juju topology.
-
-        Args:
-            path_str: either a rules file or a dir of rules files.
-            recursive: whether to read files recursively or not (no impact if `path` is a file).
-
-        Raises:
-            InvalidAlertRulePathError: if the provided path is invalid.
-        """
-        path = Path(path_str)  # type: Path
-        if path.is_dir():
-            self.alert_groups.extend(self._from_dir(path, recursive))
-        elif path.is_file():
-            self.alert_groups.extend(self._from_file(path.parent, path))
-        else:
-            logger.debug("The alerts file does not exist: %s", path)
-
-    def as_dict(self) -> dict:
-        """Return standard alert rules file in dict representation.
-
-        Returns:
-            a dictionary containing a single list of alert rule groups.
-            The list of alert rule groups is provided as value of the
-            "groups" dictionary key.
-        """
-        return {"groups": self.alert_groups} if self.alert_groups else {}
-
-
 def _resolve_dir_against_charm_path(charm: CharmBase, *path_elements: str) -> str:
     """Resolve the provided path items against the directory of the main file.
 
@@ -1152,7 +883,7 @@ class LokiPushApiProvider(Object):
         *,
         port: Union[str, int] = 3100,
         scheme: str = "http",
-        address: str = "localhost",
+        address: str = "",
         path: str = "loki/api/v1/push",
     ):
         """A Loki service provider.
@@ -1167,7 +898,9 @@ class LokiPushApiProvider(Object):
                 other charms that consume metrics endpoints.
             port: an optional port of the Loki service (default is "3100").
             scheme: an optional scheme of the Loki API URL (default is "http").
-            address: an optional address of the Loki service (default is "localhost").
+            address: DEPRECATED. This argument is ignored and will be removed in v2.
+                It is kept for backward compatibility.
+                Use `update_endpoint()` instead.
             path: an optional path of the Loki API URL (default is "loki/api/v1/push")
 
         Raises:
@@ -1183,14 +916,23 @@ class LokiPushApiProvider(Object):
         _validate_relation_by_interface_and_direction(
             charm, relation_name, RELATION_INTERFACE_NAME, RelationRole.provides
         )
+
+        if address != "":
+            warnings.warn(
+                "The 'address' parameter is deprecated and will be removed in v2. "
+                "Use 'update_endpoint()' instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         super().__init__(charm, relation_name)
         self._charm = charm
         self._relation_name = relation_name
-        self._tool = CosTool(self)
+        self._tool = CosTool("logql")
         self.port = int(port)
         self.scheme = scheme
-        self.address = address
         self.path = path
+        self._custom_url = None
 
         events = self._charm.on[relation_name]
         self.framework.observe(self._charm.on.upgrade_charm, self._on_lifecycle_event)
@@ -1304,6 +1046,14 @@ class LokiPushApiProvider(Object):
         """
         relation.data[self._charm.unit]["public_address"] = socket.getfqdn() or ""
         self.update_endpoint(relation=relation)
+
+        # Ensure promtail binary URL is set in app data. This is normally done on
+        # relation_joined, but charms using the reconcile pattern may miss that event
+        # if the workload container is not yet ready when the relation is first established.
+        if self._charm.unit.is_leader():
+            if not relation.data[self._charm.app].get("promtail_binary_zip_url"):
+                relation.data[self._charm.app].update(self._promtail_binary_url)
+
         return self._should_update_alert_rules(relation)
 
     @property
@@ -1328,6 +1078,11 @@ class LokiPushApiProvider(Object):
         host address change because the charmed operator becomes connected to an
         Ingress after the `logging` relation is established.
 
+        To make this library reconciler-friendly, the endpoint URL was made sticky i.e., once the
+        endpoint is updated with a custom URL, using the public method, it cannot be unset. Users
+        of this method should set the "url" arg to an internal URL if the charms ingress is no
+        longer available.
+
         Args:
             url: An optional url value to update relation data.
             relation: An optional instance of `class:ops.model.Relation` to update.
@@ -1341,7 +1096,10 @@ class LokiPushApiProvider(Object):
         else:
             relations_list = [relation]
 
-        endpoint = self._endpoint(url or self._url)
+        if url:
+            self._custom_url = url
+
+        endpoint = self._endpoint(self._custom_url or self._url)
 
         for relation in relations_list:
             relation.data[self._charm.unit].update({"endpoint": json.dumps(endpoint)})
@@ -1354,7 +1112,7 @@ class LokiPushApiProvider(Object):
 
         Return url to loki, including port number, but without the endpoint subpath.
         """
-        return "http://{}:{}".format(socket.getfqdn(), self.port)
+        return f"{self.scheme}://{socket.getfqdn()}:{self.port}"
 
     def _endpoint(self, url) -> dict:
         """Get Loki push API endpoint for a given url.
@@ -1431,9 +1189,10 @@ class LokiPushApiProvider(Object):
                 )
                 continue
 
-            _, errmsg = self._tool.validate_alert_rules(alert_rules)
+            _, errmsg = self._tool.validate_alert_rules(cast(OfficialRuleFileFormat, alert_rules))
             if errmsg:
-                relation.data[self._charm.app]["event"] = json.dumps({"errors": errmsg})
+                if self._charm.unit.is_leader():
+                    relation.data[self._charm.app]["event"] = json.dumps({"errors": errmsg})
                 continue
 
             alerts[identifier] = alert_rules
@@ -1545,11 +1304,13 @@ class ConsumerBase(Object):
         skip_alert_topology_labeling: bool = False,
         *,
         forward_alert_rules: bool = True,
+        extra_alert_labels: Dict = {},
     ):
         super().__init__(charm, relation_name)
         self._charm = charm
         self._relation_name = relation_name
         self._forward_alert_rules = forward_alert_rules
+        self._extra_alert_labels = extra_alert_labels
         self.topology = JujuTopology.from_charm(charm)
 
         try:
@@ -1565,16 +1326,32 @@ class ConsumerBase(Object):
 
         self._recursive = recursive
 
+    @staticmethod
+    def _inject_extra_labels_to_alert_rules(rules: Dict, extra_alert_labels: Dict) -> Dict:
+        """Return a copy of the rules dict with extra labels injected."""
+        result = copy.deepcopy(rules)
+        for group in result.get("groups", []):
+            for rule in group.get("rules", []):
+                rule.setdefault("labels", {}).update(extra_alert_labels)
+        return result
+
     def _handle_alert_rules(self, relation):
         if not self._charm.unit.is_leader():
             return
 
         alert_rules = (
-            AlertRules(None) if self._skip_alert_topology_labeling else AlertRules(self.topology)
+            AlertRules(query_type="logql")
+            if self._skip_alert_topology_labeling
+            else AlertRules(query_type="logql", topology=self.topology)
         )
         if self._forward_alert_rules:
             alert_rules.add_path(self._alert_rules_path, recursive=self._recursive)
         alert_rules_as_dict = alert_rules.as_dict()
+
+        if self._extra_alert_labels:
+            alert_rules_as_dict = ConsumerBase._inject_extra_labels_to_alert_rules(
+                alert_rules_as_dict, self._extra_alert_labels
+            )
 
         relation.data[self._charm.app]["metadata"] = json.dumps(self.topology.as_dict())
         relation.data[self._charm.app]["alert_rules"] = json.dumps(
@@ -1587,26 +1364,44 @@ class ConsumerBase(Object):
         """Fetch Loki Push API endpoints sent from LokiPushApiProvider through relation data.
 
         Returns:
-            A list of dictionaries with Loki Push API endpoints, for instance:
+            A list of unique dictionaries with Loki Push API endpoints, for instance:
             [
                 {"url": "http://loki1:3100/loki/api/v1/push"},
                 {"url": "http://loki2:3100/loki/api/v1/push"},
             ]
         """
-        endpoints = []  # type: list
+        endpoints = []
+        seen_urls = set()
 
         for relation in self._charm.model.relations[self._relation_name]:
             for unit in relation.units:
                 if unit.app == self._charm.app:
-                    # This is a peer unit
                     continue
 
-                endpoint = relation.data[unit].get("endpoint")
-                if endpoint:
-                    deserialized_endpoint = json.loads(endpoint)
-                    endpoints.append(deserialized_endpoint)
+                if not (endpoint := relation.data[unit].get("endpoint")):
+                    continue
+
+                deserialized_endpoint = json.loads(endpoint)
+                url = deserialized_endpoint.get("url")
+
+                # Deduplicate by URL.
+                # With loki-k8s we have ingress-per-unit, so in that case
+                # we do want to collect the URLs of all the units.
+                # With loki-coordinator-k8s, even when the coordinator
+                # is scaled, we want to advertise only one URL.
+                # Without deduplication, we'd end up with the same
+                # tls config section in the promtail config file, in which
+                # case promtail immediately exits with the following error:
+                # [promtail] level=error ts=<timestamp> msg="error creating promtail" error="failed to create client manager: duplicate client configs are not allowed, found duplicate for name: "
+
+                if not url or url in seen_urls:
+                    continue
+
+                seen_urls.add(url)
+                endpoints.append(deserialized_endpoint)
 
         return endpoints
+
 
 
 class LokiPushApiConsumer(ConsumerBase):
@@ -1624,6 +1419,7 @@ class LokiPushApiConsumer(ConsumerBase):
         *,
         refresh_event: Optional[Union[BoundEvent, List[BoundEvent]]] = None,
         forward_alert_rules: bool = True,
+        extra_alert_labels: Dict = {},
     ):
         """Construct a Loki charm client.
 
@@ -1650,6 +1446,7 @@ class LokiPushApiConsumer(ConsumerBase):
             recursive: Whether to scan for rule files recursively.
             skip_alert_topology_labeling: whether to skip the alert topology labeling.
             forward_alert_rules: a boolean flag to toggle forwarding of charmed alert rules.
+            extra_alert_labels: Dict of extra labels to inject alert rules with.
             refresh_event: an optional bound event or list of bound events which
                 will be observed to re-set scrape job data (IP address and others)
 
@@ -1683,6 +1480,7 @@ class LokiPushApiConsumer(ConsumerBase):
             recursive,
             skip_alert_topology_labeling,
             forward_alert_rules=forward_alert_rules,
+            extra_alert_labels=extra_alert_labels,
         )
         events = self._charm.on[relation_name]
         self.framework.observe(self._charm.on.upgrade_charm, self._on_lifecycle_event)
@@ -2696,123 +2494,6 @@ class LogForwarder(ConsumerBase):
         endpoints = self._extract_urls(relation)
 
         return endpoints
-
-
-class CosTool:
-    """Uses cos-tool to inject label matchers into alert rule expressions and validate rules."""
-
-    _path = None
-    _disabled = False
-
-    def __init__(self, charm):
-        self._charm = charm
-
-    @property
-    def path(self):
-        """Lazy lookup of the path of cos-tool."""
-        if self._disabled:
-            return None
-        if not self._path:
-            self._path = self._get_tool_path()
-            if not self._path:
-                logger.debug("Skipping injection of juju topology as label matchers")
-                self._disabled = True
-        return self._path
-
-    def apply_label_matchers(self, rules) -> dict:
-        """Will apply label matchers to the expression of all alerts in all supplied groups."""
-        if not self.path:
-            return rules
-        for group in rules["groups"]:
-            rules_in_group = group.get("rules", [])
-            for rule in rules_in_group:
-                topology = {}
-                # if the user for some reason has provided juju_unit, we'll need to honor it
-                # in most cases, however, this will be empty
-                for label in [
-                    "juju_model",
-                    "juju_model_uuid",
-                    "juju_application",
-                    "juju_charm",
-                    "juju_unit",
-                ]:
-                    if label in rule["labels"]:
-                        topology[label] = rule["labels"][label]
-
-                rule["expr"] = self.inject_label_matchers(rule["expr"], topology)
-        return rules
-
-    def validate_alert_rules(self, rules: dict) -> Tuple[bool, str]:
-        """Will validate correctness of alert rules, returning a boolean and any errors."""
-        if not self.path:
-            logger.debug("`cos-tool` unavailable. Not validating alert correctness.")
-            return True, ""
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            rule_path = Path(tmpdir + "/validate_rule.yaml")
-
-            # Smash "our" rules format into what upstream actually uses, which is more like:
-            #
-            # groups:
-            #   - name: foo
-            #     rules:
-            #       - alert: SomeAlert
-            #         expr: up
-            #       - alert: OtherAlert
-            #         expr: up
-            transformed_rules = {"groups": []}  # type: ignore
-            for rule in rules["groups"]:
-                transformed_rules["groups"].append(rule)
-
-            rule_path.write_text(yaml.dump(transformed_rules))
-            args = [str(self.path), "--format", "logql", "validate", str(rule_path)]
-            # noinspection PyBroadException
-            try:
-                self._exec(args)
-                return True, ""
-            except subprocess.CalledProcessError as e:
-                logger.debug("Validating the rules failed: %s", e.output)
-                return False, ", ".join([line for line in e.output if "error validating" in line])
-
-    def inject_label_matchers(self, expression, topology) -> str:
-        """Add label matchers to an expression."""
-        if not topology:
-            return expression
-        if not self.path:
-            logger.debug("`cos-tool` unavailable. Leaving expression unchanged: %s", expression)
-            return expression
-        args = [str(self.path), "--format", "logql", "transform"]
-        args.extend(
-            ["--label-matcher={}={}".format(key, value) for key, value in topology.items()]
-        )
-
-        args.extend(["{}".format(expression)])
-        # noinspection PyBroadException
-        try:
-            return self._exec(args)
-        except subprocess.CalledProcessError as e:
-            logger.debug('Applying the expression failed: "%s", falling back to the original', e)
-            print('Applying the expression failed: "{}", falling back to the original'.format(e))
-            return expression
-
-    def _get_tool_path(self) -> Optional[Path]:
-        arch = platform.processor()
-        arch = "amd64" if arch == "x86_64" else arch
-        res = "cos-tool-{}".format(arch)
-        try:
-            path = Path(res).resolve()
-            path.chmod(0o777)
-            return path
-        except NotImplementedError:
-            logger.debug("System lacks support for chmod")
-        except FileNotFoundError:
-            logger.debug('Could not locate cos-tool at: "{}"'.format(res))
-        return None
-
-    def _exec(self, cmd) -> str:
-        result = subprocess.run(cmd, check=True, stdout=subprocess.PIPE)
-        output = result.stdout.decode("utf-8").strip()
-        return output
 
 
 def charm_logging_config(

--- a/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
+++ b/lib/charms/prometheus_k8s/v1/prometheus_remote_write.py
@@ -13,6 +13,7 @@ the Prometheus remote_write API, that is, they can receive metrics data over rem
 should use the `PrometheusRemoteWriteProducer`.
 """
 
+import copy
 import json
 import logging
 import os
@@ -22,11 +23,11 @@ import socket
 import subprocess
 import tempfile
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
 import yaml
 from cosl import JujuTopology
-from cosl.rules import AlertRules, generic_alert_groups
+from cosl.rules import HOST_METRICS_MISSING_RULE_NAME, AlertRules, generic_alert_groups
 from ops.charm import (
     CharmBase,
     HookEvent,
@@ -46,7 +47,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 12
 
 PYDEPS = ["cosl"]
 
@@ -403,9 +404,14 @@ class PrometheusRemoteWriteConsumer(Object):
         alert_rules_path: str = DEFAULT_ALERT_RULES_RELATIVE_PATH,
         refresh_event: Optional[Union[BoundEvent, List[BoundEvent]]] = None,
         *,
+        peer_relation_name: str,
         forward_alert_rules: bool = True,
+        extra_alert_labels: Dict = {},
     ):
         """API to manage a required relation with the `prometheus_remote_write` interface.
+
+        Since remote write consumers need to inject labels into alert expressions, they need
+        to have the cos tool binary available.
 
         Args:
             charm: The charm object that instantiated this class.
@@ -414,7 +420,9 @@ class PrometheusRemoteWriteConsumer(Object):
             alert_rules_path: Path of the directory containing the alert rules.
             refresh_event: an optional bound event or list of bound events which
                 will be observed to re-set alerts data.
+            peer_relation_name: Name of the peer relation containing units of this charm.
             forward_alert_rules: Flag to toggle forwarding of charmed alert rules.
+            extra_alert_labels: Dict of extra labels to inject alert rules with.
 
         Raises:
             RelationNotFoundError: If there is no relation in the charm's metadata.yaml
@@ -444,9 +452,10 @@ class PrometheusRemoteWriteConsumer(Object):
         self._relation_name = relation_name
         self._alert_rules_path = alert_rules_path
         self._forward_alert_rules = forward_alert_rules
-
+        self._extra_alert_labels = extra_alert_labels
+        self._peer_relation_name = peer_relation_name
         self.topology = JujuTopology.from_charm(charm)
-
+        self._tool = CosTool(self._charm)
         on_relation = self._charm.on[self._relation_name]
 
         self.framework.observe(on_relation.relation_joined, self._handle_endpoints_changed)
@@ -494,25 +503,52 @@ class PrometheusRemoteWriteConsumer(Object):
     def _push_alerts_to_relation_databag(self, relation: Relation) -> None:
         if not self._charm.unit.is_leader():
             return
+        peer_relations = self._charm.model.get_relation(self._peer_relation_name)
+        unit_names = (
+            {unit.name for unit in peer_relations.units} if peer_relations else set()
+        ) | {self._charm.unit.name}
 
         alert_rules = AlertRules(query_type="promql", topology=self.topology)
+
         if self._forward_alert_rules:
-            alert_rules.add_path(self._alert_rules_path)
-            alert_rules.add(
-                generic_alert_groups.aggregator_rules, group_name_prefix=self.topology.identifier
+            agg_rules = self._duplicate_rules_per_unit(
+                copy.deepcopy(generic_alert_groups.aggregator_rules),
+                unit_names,
+                rule_names_to_duplicate=[HOST_METRICS_MISSING_RULE_NAME],
+                is_subordinate=self._charm.meta.subordinate,
             )
+            alert_rules.add(agg_rules, group_name_prefix=self.topology.identifier)
+
+            alert_rules.add_path(self._alert_rules_path)
 
         alert_rules_as_dict = alert_rules.as_dict()
 
+        if self._extra_alert_labels:
+            alert_rules_as_dict = (
+                PrometheusRemoteWriteConsumer._inject_extra_labels_to_alert_rules(
+                    alert_rules_as_dict, self._extra_alert_labels
+                )
+            )
         relation.data[self._charm.app]["alert_rules"] = json.dumps(alert_rules_as_dict)
 
     def reload_alerts(self) -> None:
         """Reload alert rules from disk and push to relation data."""
         self._push_alerts_to_all_relation_databags(None)
 
+    @staticmethod
+    def _inject_extra_labels_to_alert_rules(rules: Dict, extra_alert_labels: Dict) -> Dict:
+        """Return a copy of the rules dict with extra labels injected."""
+        result = copy.deepcopy(rules)
+        for group in result.get("groups", []):
+            for rule in group.get("rules", []):
+                rule.setdefault("labels", {}).update(extra_alert_labels)
+        return result
+
     @property
     def endpoints(self) -> List[Dict[str, str]]:
         """A config object ready to be dropped into a prometheus config file.
+
+        The endpoints are deduplicated.
 
         The format of the dict is specified in the official prometheus docs:
         https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write
@@ -527,17 +563,76 @@ class PrometheusRemoteWriteConsumer(Object):
                 if unit.app is self._charm.app:
                     # This is a peer unit
                     continue
+                if not (unit_databag := relation.data.get(unit)):
+                    continue
+                if not (remote_write := unit_databag.get("remote_write")):
+                    continue
 
-                remote_write = relation.data[unit].get("remote_write")
-                if remote_write:
-                    deserialized_remote_write = json.loads(remote_write)
-                    endpoints.append(
-                        {
-                            "url": deserialized_remote_write["url"],
-                        }
-                    )
+                deserialized_remote_write = json.loads(remote_write)
+                endpoints.append(
+                    {
+                        "url": deserialized_remote_write["url"],
+                    }
+                )
 
-        return endpoints
+        # When multiple units of the remote-write server are behind an ingress
+        # (e.g. mimir), relation data would end up with the same ingress url
+        # for all units.
+        # Deduplicate the endpoints by converting each dict to a tuple of
+        # dict.items(), throwing them into a set, and then converting them
+        # back to dictionaries
+        deduplicated_endpoints = [dict(t) for t in {tuple(d.items()) for d in endpoints}]
+        return deduplicated_endpoints
+
+    def _duplicate_rules_per_unit(
+        self,
+        alert_rules: Dict[str, Any],
+        peer_unit_names: Set[str],
+        rule_names_to_duplicate: List[str],
+        is_subordinate: bool = False,
+    ) -> Dict[str, Any]:
+        """Duplicate alert rule per unit in peer_units list.
+
+        Args:
+            alert_rules: A dictionary where key = "groups" and value is a list of rules.
+            peer_unit_names: A set of unit names (str) representing units of this charm.
+            rule_names_to_duplicate: A list of alert rule names to be duplicated.
+            is_subordinate: A boolean denoting whether the charm duplicating alert rules is a subordinate or not. If yes, the severity of the alerts in duplicate_keys needs to be set to critical.
+
+        Returns:
+            A Dict[str, any] the updated alert rules with the rules specified in rule_names_to_duplicate
+            duplicated per unit. The list is to be assigned to the `groups` attribute of an object of type AlertRules.
+        """
+        updated_alert_rules = copy.deepcopy(alert_rules)
+
+        for group in updated_alert_rules.get("groups", {}):
+            new_rules = []
+            for rule in group["rules"]:
+                if rule.get("alert", "") not in rule_names_to_duplicate:
+                    new_rules.append(rule)
+                else:
+                    for name in peer_unit_names:
+                        juju_unit = name
+                        modified_rule = copy.deepcopy(rule)
+
+                        # Inject juju_unit alert label.
+                        modified_rule["labels"]["juju_unit"] = juju_unit
+
+                        # Inject juju_unit label matcher.
+                        modified_rule["expr"] = self._tool.inject_label_matchers(
+                            re.sub(r"%%juju_unit%%,?", "", modified_rule["expr"]),
+                            {"juju_unit": juju_unit},
+                        )
+
+                        # If the charm is a subordinate, the severity of the alerts need to be bumped to critical.
+                        modified_rule["labels"]["severity"] = (
+                            "critical" if is_subordinate else "warning"
+                        )
+
+                        new_rules.append(modified_rule)
+
+            group["rules"] = new_rules
+        return updated_alert_rules
 
 
 class PrometheusRemoteWriteAlertsChangedEvent(EventBase):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
   "cosl",
   "httpx",
   "lightkube",
+  "charmed-service-mesh-helpers",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
   "cosl",
   "httpx",
   "lightkube",
+  "lightkube-extensions",
   "charmed-service-mesh-helpers",
 ]
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -39,7 +39,7 @@ class K6K8sCharm(CharmBase):
         if not self.container.can_connect():
             return
 
-        self.prometheus = PrometheusRemoteWriteConsumer(self)
+        self.prometheus = PrometheusRemoteWriteConsumer(self, peer_relation_name="k6")
         self.loki = LokiPushApiConsumer(self)
         self.k6_tests = K6TestRequirer(self)
         prometheus_endpoints = self.prometheus.endpoints

--- a/uv.lock
+++ b/uv.lock
@@ -248,6 +248,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
 name = "jubilant"
 version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -268,6 +280,7 @@ dependencies = [
     { name = "cosl" },
     { name = "httpx" },
     { name = "lightkube" },
+    { name = "lightkube-extensions" },
     { name = "ops", extra = ["tracing"] },
     { name = "pyyaml" },
 ]
@@ -296,6 +309,7 @@ requires-dist = [
     { name = "httpx" },
     { name = "jubilant", marker = "extra == 'dev'" },
     { name = "lightkube" },
+    { name = "lightkube-extensions" },
     { name = "ops", extras = ["tracing"], specifier = ">=2.17" },
     { name = "ops-scenario", marker = "extra == 'dev'" },
     { name = "pyright", marker = "extra == 'dev'" },
@@ -325,12 +339,45 @@ wheels = [
 ]
 
 [[package]]
+name = "lightkube-extensions"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "charmed-service-mesh-helpers" },
+    { name = "jinja2" },
+    { name = "lightkube" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/a6/e85fceea9cb364d3940ec8db727d98879312a49688fda6dbc2ec06ce352c/lightkube_extensions-1.0.0.tar.gz", hash = "sha256:8f3f4a378a4422e6a9a6fd45ca30698760cacb97c2ddec0730f6a565bdfc7375", size = 18347, upload-time = "2026-05-14T10:48:07.214Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/51/0fe55efd0bd5e235bbbaf047498434b8171cc016ff8baaaf3c37c6585bf0/lightkube_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4a7a809d0f242e186a5433565a021e7fc67f6b139901cb0c3f1b8e528cc6eb41", size = 19372, upload-time = "2026-05-14T10:48:08.292Z" },
+]
+
+[[package]]
 name = "lightkube-models"
 version = "1.35.0.8"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c8/03/36ecf94356f5dc40c76d9f9732eba3e33e8b873d9e6a874f25ad0504be21/lightkube_models-1.35.0.8.tar.gz", hash = "sha256:dbc624596a7d94e6c43c5deda972be964202e0e8f26e2ab8e61d589d710b5e22", size = 244553, upload-time = "2025-12-25T22:30:58.526Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a1/1d/8f77a83dcfedac74248af3b65390b2f5bca65ca8131ee18a1895cd10d4a7/lightkube_models-1.35.0.8-py3-none-any.whl", hash = "sha256:d01fce42f96baf47a77a571bff59d6a513e96ae043fc03cfaaaaf79c609c4441", size = 305779, upload-time = "2025-12-25T22:30:57.192Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
 ]
 
 [[package]]
@@ -577,27 +624,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.15"
+version = "0.15.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/84/6f/a76f7d96e5c962f5b69cee865e49c15c1116897c01990faa8a57edb62e7f/ruff-0.15.15.tar.gz", hash = "sha256:b8dff018130b46d8e5bf0f926ef6b60cf871d6d5ae45fc9334e09632daa741d6", size = 4706985, upload-time = "2026-05-28T14:16:57.784Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/bd/5f7ec371001337d8fa61701c186ff8b613ecac1651848c5950f4c4d5f2e9/ruff-0.15.16.tar.gz", hash = "sha256:d05e78d38c78caf020b03789e25106c93017db5a0cb6e2819885018c61343b78", size = 4714267, upload-time = "2026-06-04T16:33:09.974Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/9d/3a45c05b8ab04b4705989de70a79008e27c8003296a0feaee9edc18dd7e9/ruff-0.15.15-py3-none-linux_armv6l.whl", hash = "sha256:cf93e5388f412e1b108b1f8b34a6e036b70fe8aff89393befad96fe48670311b", size = 10710652, upload-time = "2026-05-28T14:16:06.701Z" },
-    { url = "https://files.pythonhosted.org/packages/05/66/da974431624bf3b49f6ee1f9543c02d929ff1cba78b0d5a79c38cf21f744/ruff-0.15.15-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ac5a646d1f6a7dadd5d50842dae2c1f9862ac887ef5d1b1375e02def791fde6e", size = 11096615, upload-time = "2026-05-28T14:16:23.313Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/09/7443452e5d290230a712103f2fdceeef7184f3ec99a2bd01c8be78aaceb5/ruff-0.15.15-py3-none-macosx_11_0_arm64.whl", hash = "sha256:77d955a431430c66f72dd94e379ad38a16daea3d25094872ac4edf9e797be530", size = 10436683, upload-time = "2026-05-28T14:16:40.974Z" },
-    { url = "https://files.pythonhosted.org/packages/53/01/d330c26a57fa4f3943a14424904027428315b700fe4d14a84bb123a649e5/ruff-0.15.15-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7614ee79c69788cf6cedd568069ade9cecc22a1ad20494efe8d0c9ebb4b622d4", size = 10769064, upload-time = "2026-05-28T14:16:28.905Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/85/cc8770f8bdff541b1da8392d1634141fe4a0e3f4ee596605959b7906c27f/ruff-0.15.15-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3cdb1679e06a1f6b47bc384714ae96f6e2fb65ca441eb78c43d2ca554176ce1f", size = 10511987, upload-time = "2026-05-28T14:16:43.732Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/29/8c190c1472b63013583ba391f3342036e02010544c1270455ed8e519bdf3/ruff-0.15.15-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2728b93d7b23a603ea2c0ac6eb73d760bd38ec9de35f35fb41e18f7a3fee7622", size = 11275100, upload-time = "2026-05-28T14:16:55.244Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/6b/7e145ce2cc8e63d6834eca03d83a0e18d121def5c69f91b4cf4011ed4879/ruff-0.15.15-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be582fcc0db438902c7792b08d6ddf6c9b9e21addaa10092c2c741cfb09e5a45", size = 12176903, upload-time = "2026-05-28T14:16:14.368Z" },
-    { url = "https://files.pythonhosted.org/packages/80/a3/d5974637f68e451f7fadf015cf3101d1cd7d8ba5027cffe0b9e3826ebe6b/ruff-0.15.15-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7aa77465b8ecaf1a27bea098d696f7fed5e1eccbd10b321b682d6de586ae5627", size = 11404550, upload-time = "2026-05-28T14:16:20.138Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/1c/e6e5e568f22be4fb05d6244234aba384c06b451252453b821e1a529263cf/ruff-0.15.15-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48decfa11d740de4889de623be1463308346312f2409a56e24aa280c86162dc4", size = 11382027, upload-time = "2026-05-28T14:16:46.615Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/01/170921b49fcd2e8858825593f91cf7146c3e40a5c3e6df763e4bb0484dde/ruff-0.15.15-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a5015088452ca0081387063649ec67f06d3d1d6b8b936a1f836b5e9657ecd48c", size = 11366041, upload-time = "2026-05-28T14:16:26.247Z" },
-    { url = "https://files.pythonhosted.org/packages/87/54/a7bad711d7de93254e15e06a4c375b89a03d18de45d3e5dcc86a4472fb1a/ruff-0.15.15-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f5294aab6356c81600fcdea3a62bb1b924dfd5e91767c12318d3f68f86af57cd", size = 10741795, upload-time = "2026-05-28T14:16:17.11Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/31/38c075963668f8b41c6914ee0f6f318727fbe30ab9145cb29e6df464c5fa/ruff-0.15.15-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:db5bd4d802415cca656dc1616070b725952d6ae95eb5d4831e49fbd94a38f75f", size = 10511117, upload-time = "2026-05-28T14:16:31.767Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/96/6ff689e1f7e375d1d97075eca022f74c2bab59554a432fe4d2e6f091986a/ruff-0.15.15-py3-none-musllinux_1_2_i686.whl", hash = "sha256:587a6278ed42059191c1a466e490bd7930fb50bd2e255398bc29616c895a61cb", size = 10994867, upload-time = "2026-05-28T14:16:35.149Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/c2/5dce0ab9f92a8d534fa62b9bf9caca3eddb8c1a81b616f5e195ada4f0d6e/ruff-0.15.15-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:df0c1c084f5f4be9812f61518a45c440d3c30d69ce4bf6c5270e66d38338f02a", size = 11482101, upload-time = "2026-05-28T14:16:49.598Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/c0/1003b60edd697c649faf61f1a34094b1abb38fb3d1181e3f895781250a08/ruff-0.15.15-py3-none-win32.whl", hash = "sha256:29428ea79694afbe756d45fd59b36f22b6b020dc0443cf7de0173046236964b9", size = 10716774, upload-time = "2026-05-28T14:16:52.337Z" },
-    { url = "https://files.pythonhosted.org/packages/02/a8/1269eddd6945a06c23f055ef7848886e37cf9d6a8bebb386a3115f01470c/ruff-0.15.15-py3-none-win_amd64.whl", hash = "sha256:8df0323902e15e24bc4bf246da830573d3cf3352bd0b9a164eab335d111ff4a4", size = 11868463, upload-time = "2026-05-28T14:16:11.333Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/b2/920464c907b191e37469d477a1aa8bc048b8f36c4c1610dfa4ab87b39e18/ruff-0.15.15-py3-none-win_arm64.whl", hash = "sha256:3c8ceca6792f38196b8f589bc92eccd03eef286602da92e5dc05cc42ef6441b7", size = 11138498, upload-time = "2026-05-28T14:16:38.425Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/42/53ef1c3953f157956db9bf7861e3bc50b9b887ce93300aa48cdba8336fe6/ruff-0.15.16-py3-none-linux_armv6l.whl", hash = "sha256:6ac3c0b3969cc6cf6b158c4e2f8f682acb58e7d700d8a44b65ecdc72d66ab0b2", size = 10709025, upload-time = "2026-06-04T16:32:51.935Z" },
+    { url = "https://files.pythonhosted.org/packages/93/9a/a79159346f19134a956607754e57d8d128f7a4c00f4ad2f7514d224c172c/ruff-0.15.16-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:197c207ed75ffba54a0dec23db4aa939a27a3053073e085e0042433cbdc58e4a", size = 11063550, upload-time = "2026-06-04T16:32:42.24Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/72/3ce2ac000a5299ec238e01f51397b3b653c93b077d9b1bfe8715bb895f20/ruff-0.15.16-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3a39fec45ab316cc23e7558f23fea4a70403ddb5648ea9a4a3854a16973d0071", size = 10421345, upload-time = "2026-06-04T16:32:37.251Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c2/cc7fad3ec9169373f5b6a18f1917b91080feec40c3f9658334a1d28e2f03/ruff-0.15.16-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ba93191d79003116b95128c9d306e045200fdbd0bccb782b110f3cd1d4abc5cf", size = 10757217, upload-time = "2026-06-04T16:32:54.722Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d2/3474009eaa0a65b31fa7152a2fad5e2f050c640ceb1e6b02ee6922e94c82/ruff-0.15.16-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c6ee4b90520630120ef032aa5cc10db483852dff950e78b1d717e2993a61ac8d", size = 10507035, upload-time = "2026-06-04T16:33:05.343Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/81/b7ae6ccbd11f0c8dc3d5d67fc4be9b57ff57ca86ba56152021378e1277f2/ruff-0.15.16-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4e4215bc938bc3c8215c1472c1aa437e310fee20cd427335fec9d7e609563628", size = 11255291, upload-time = "2026-06-04T16:32:49.49Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/e1/46e526f1a7cc90857ce6ddf25fbb77eb6568651ac38d71b033af07076dd5/ruff-0.15.16-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7c8d26be963b090f10e29abc8b3e74a2a321f6fa34e02424e30b5af89350ecbb", size = 12124922, upload-time = "2026-06-04T16:33:07.821Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/da/5c791b088b596b24d0deb967fa28ae02ad751a140c0b9ea81c5ab915d6c0/ruff-0.15.16-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f198cf4123602a2280ed46c307bcbafe41758d6fee5b456b6b6058ca1514b3b4", size = 11332186, upload-time = "2026-06-04T16:33:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/72/11/5da87abe20047c8962361473923ebb2f62b595250126aadfad8c20649c1e/ruff-0.15.16-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb27515fa6240fb586ae82b901a59e67d24acff86f2190b433dc542fe0435aeb", size = 11373541, upload-time = "2026-06-04T16:32:47.007Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/2a/8554754c23a854ae3fd6b507e36ad61ddb121e298c6d5d617dec94ed0f14/ruff-0.15.16-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a267c46ba1593fc26b8eecbea050b39d40c0b6bb7781ee11c90a02cd10032951", size = 11353014, upload-time = "2026-06-04T16:32:34.795Z" },
+    { url = "https://files.pythonhosted.org/packages/62/25/62ea41529ec89f742ea3fed9cb1059c72877ec7cf9b9e99ac9cf3294d1d9/ruff-0.15.16-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:528c68f39a91498a8d50e91ff5985df3d105782bab49cc378e73ac26bff083e8", size = 10737467, upload-time = "2026-06-04T16:32:26.348Z" },
+    { url = "https://files.pythonhosted.org/packages/90/17/334d3ad9de4d40f9dd58fdd09e35ce64553bb501e2f19a839e2fb6be14fc/ruff-0.15.16-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:7ed55c58950df60589a9a7a5d2f8fa5f54ebd287163be805adfe6ee95a9de123", size = 10521910, upload-time = "2026-06-04T16:32:32.54Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/bd/3ac7c6ae77a885c1004b3dda2446ea401768d24f851c14b4ad4b24f6639c/ruff-0.15.16-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d482feaf51512b50f9790ceb417a56a61dd1e9d9bf967662b9ed27c01b34f53a", size = 10979190, upload-time = "2026-06-04T16:32:57.492Z" },
+    { url = "https://files.pythonhosted.org/packages/33/d7/609546e6a413c3f216fbf2a50c928f97c80939154f6a0503114094a86191/ruff-0.15.16-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1e15bc8c94513dae2a40cc9ef07c94fdd4ecc9e29dabebeebe170f952322c9e3", size = 11477014, upload-time = "2026-06-04T16:32:44.687Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0d/f2cd247ad32633a5c36e97141a2c21b11c6279f7957bc2ff360b1e08fddd/ruff-0.15.16-py3-none-win32.whl", hash = "sha256:580378f7bd4aa25f72e74aa54948a9622f142b1e509521dd10902e886681cc1e", size = 10735541, upload-time = "2026-06-04T16:32:30.145Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9e/02e845ef151b1dee585e55c4739f8e1734ae1d9f1221dff65761c162208b/ruff-0.15.16-py3-none-win_amd64.whl", hash = "sha256:408256017284eddf98fff77b29aa4fb30f586042d535b2d9befc6512f400aaec", size = 11843403, upload-time = "2026-06-04T16:32:39.76Z" },
+    { url = "https://files.pythonhosted.org/packages/15/19/016553f86f207450aebebc2b2b5088d086b901cc8186c02ac4284db3bd88/ruff-0.15.16-py3-none-win_arm64.whl", hash = "sha256:8cd61783afb39638a7133ef0d2dfb1e91277593962f81b5a8423eb0b888a6121", size = 11134555, upload-time = "2026-06-04T16:33:00.136Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -34,6 +34,19 @@ wheels = [
 ]
 
 [[package]]
+name = "charmed-service-mesh-helpers"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ops" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/b1/01f400a87af69198f90abfd74d4f9e53878fb015e6ccb61ebbc4370dcf6b/charmed_service_mesh_helpers-0.6.0.tar.gz", hash = "sha256:2a606679c467c68744d439641aa8fe9fc533eebfaea97fc3662e87266fd0d786", size = 16869, upload-time = "2026-03-17T12:19:59Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/57/f3432cace60a3116bb7f9b98aae42638278777da3fdf78aa49e974d43920/charmed_service_mesh_helpers-0.6.0-py3-none-any.whl", hash = "sha256:7160e5c1585efd2e369ccc6257c8e5964bbc52bce21a053ccba010e29b1fb12a", size = 16436, upload-time = "2026-03-17T12:19:59.667Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.7"
 source = { registry = "https://pypi.org/simple" }
@@ -206,11 +219,23 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.16"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
 ]
 
 [[package]]
@@ -239,6 +264,7 @@ name = "k6-k8s"
 version = "0.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "charmed-service-mesh-helpers" },
     { name = "cosl" },
     { name = "httpx" },
     { name = "lightkube" },
@@ -263,6 +289,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "charmed-service-mesh-helpers" },
     { name = "codespell", marker = "extra == 'dev'" },
     { name = "cosl" },
     { name = "coverage", extras = ["toml"], marker = "extra == 'dev'" },
@@ -356,16 +383,17 @@ wheels = [
 
 [[package]]
 name = "ops"
-version = "3.7.1"
+version = "2.23.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "importlib-metadata" },
     { name = "opentelemetry-api" },
     { name = "pyyaml" },
     { name = "websocket-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/60/ad398d889fd03b1b4f950fad54ad4d0cf7a81fde21f9866a8139c8f03684/ops-3.7.1.tar.gz", hash = "sha256:1765bf6d1cff376ea27608542e183b055c89f2c5f54bca602072bcc817195abc", size = 582424, upload-time = "2026-05-28T04:13:43.906Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/98/84789a5e15ad76e043301bbd70b4d39cffaa717ae6eecb662fd0dd0cc7af/ops-2.23.2.tar.gz", hash = "sha256:a69b0c5bc65ebd91720fc96459e81b969df851f3a6c9c855ee73de7004205987", size = 528074, upload-time = "2026-02-11T03:58:15.565Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/20/742e720af65f9ad23ae0cfe140502a10b2e74da6c63773f3999dad793661/ops-3.7.1-py3-none-any.whl", hash = "sha256:559dc6770e551da5f4b9686a5605ed927c140182eb38bcc31c1c531c2f98923a", size = 212723, upload-time = "2026-05-28T04:13:39.845Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/00/65da7c96d0f9e13c4de3bdd2e3717259fe723ff4bd4e5dc714164f851032/ops-2.23.2-py3-none-any.whl", hash = "sha256:9cab0c6bc46eeff2e96777128200c3ef872b55641b12f07dc4fd6fe3103954be", size = 188415, upload-time = "2026-02-11T03:58:13.693Z" },
 ]
 
 [package.optional-dependencies]
@@ -375,31 +403,29 @@ tracing = [
 
 [[package]]
 name = "ops-scenario"
-version = "8.7.1"
+version = "7.23.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ops" },
     { name = "pyyaml" },
-    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/06/705b452b9145107978eb0400a1e751839ed1ec59dc152fa45a2e5fba0ea3/ops_scenario-8.7.1.tar.gz", hash = "sha256:25b24c7c612b8e089ad05f24a47c138999d1cc0a2683e0f7c74e0520c7bb6043", size = 78576, upload-time = "2026-05-28T04:13:45.292Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/e7/1514b9c27b9364ec1d04791b0fb76d1a629c8cc73f90fbf6dd867457c914/ops_scenario-7.23.2.tar.gz", hash = "sha256:327dda8b3c871ccf16246ed4f8c7e093526af42093549976596cede58cbc8488", size = 70017, upload-time = "2026-02-11T03:58:16.553Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/45/c78501e1b8203207b7c43f62233b9fea3be5015f5230ce53d7deceb5d7a3/ops_scenario-8.7.1-py3-none-any.whl", hash = "sha256:01a8cee03c57a826b2dd9692571731d6307327cace7ac7865d9420e1136e7860", size = 69401, upload-time = "2026-05-28T04:13:41.39Z" },
+    { url = "https://files.pythonhosted.org/packages/01/15/3b59993cad1b2838c9bb20f6f2ed5297fcf490025b1ffecc27d06be1daba/ops_scenario-7.23.2-py3-none-any.whl", hash = "sha256:024b638e0ea94e8f2e3c642d4f96031b0c7ac4f39117b97107dc9a09503651b4", size = 64328, upload-time = "2026-02-11T03:58:14.916Z" },
 ]
 
 [[package]]
 name = "ops-tracing"
-version = "3.7.1"
+version = "2.23.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api" },
     { name = "opentelemetry-sdk" },
     { name = "ops" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/a4/f56c5f146cb38a1092b68fe8f29b945b982c3daebfee6854785b60641437/ops_tracing-3.7.1.tar.gz", hash = "sha256:fc433a58c868d36a64fe708ef8c9318ec925af7908490057ce6274c116f49af8", size = 28599, upload-time = "2026-05-28T04:13:46.306Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/7a/fd22f7276ad3cd3d5eb32fbdbe099d1fad8b14b4fe7d42f99e59b3f5df15/ops_tracing-2.23.2.tar.gz", hash = "sha256:888724dbb953329b9aa6d19d69e185db40f5a6f91729916f57e3c2f59c590fa4", size = 28430, upload-time = "2026-02-11T04:38:32.181Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/3c/eed4b9c677050b211c60d64128226ba8e5f48a767f86eaf46486f883e727/ops_tracing-3.7.1-py3-none-any.whl", hash = "sha256:6b7a74e61477e0e47b42460aafc1669dfee98ec2e4a2f0360f0b86e8e6c49c3f", size = 31444, upload-time = "2026-05-28T04:13:42.546Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/e7/5447c80c6c013cf08d0d6f8182af965e00ef41171b2f62713fd938bcecbf/ops_tracing-2.23.2-py3-none-any.whl", hash = "sha256:74cd11b34e9524fb999d045d4a7a626cab264d8080dd7baa67656636010bdceb", size = 31391, upload-time = "2026-02-11T04:38:31.086Z" },
 ]
 
 [[package]]
@@ -476,15 +502,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.409"
+version = "1.1.410"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/51/4e/3aa27f74211522dba7e9cbc3e74de779c6d4b654c54e50a4840623be8014/pyright-1.1.409.tar.gz", hash = "sha256:986ee05beca9e077c165758ad123667c679e050059a2546aa02473930394bc93", size = 4430434, upload-time = "2026-04-23T11:02:03.799Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/53/e4d8ea1391bd4355231be6f91bf239479aa0014260ed3fb5526eeb12a1f2/pyright-1.1.410.tar.gz", hash = "sha256:07a073b8ba6749826773c1269773efa11b93440d9a6aa60419d9a3172d6dc488", size = 4062013, upload-time = "2026-06-01T17:35:48.894Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/6b/330d8ebae582b30c2959a1ef4c3bc344ebde48c2ff0c3f113c4710735e11/pyright-1.1.409-py3-none-any.whl", hash = "sha256:aa3ea228cab90c845c7a60d28db7a844c04315356392aa09fafcee98c8c22fb3", size = 6438161, upload-time = "2026-04-23T11:02:01.309Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/33/288b5868fa00846dacf249633719d747893e54aebd196b9968ac1878a5d3/pyright-1.1.410-py3-none-any.whl", hash = "sha256:5e961bed37cacf96b3f7cd7b1da39b350a9239aa2e69138d0e88f728cfaf296c", size = 6082448, upload-time = "2026-06-01T17:35:46.387Z" },
 ]
 
 [[package]]
@@ -551,27 +577,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.14"
+version = "0.15.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/dc/8a/8bce2894573e9dae6ff4d77fe34ad727d79b9e6238ad288c5638990d90f6/ruff-0.15.14.tar.gz", hash = "sha256:48e866b165be4a9bdbf310f7d3c9a07edef2fe8cd63ffeb4e00bb590506ebf9f", size = 4700910, upload-time = "2026-05-21T14:34:55.177Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/6f/a76f7d96e5c962f5b69cee865e49c15c1116897c01990faa8a57edb62e7f/ruff-0.15.15.tar.gz", hash = "sha256:b8dff018130b46d8e5bf0f926ef6b60cf871d6d5ae45fc9334e09632daa741d6", size = 4706985, upload-time = "2026-05-28T14:16:57.784Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/c8/74a92c6ff9fcfb4f1f947126d3ebee8389276e161ecc85de5bda7cda51bd/ruff-0.15.14-py3-none-linux_armv6l.whl", hash = "sha256:8dd2db9416e487c8d4b01fa7056bb02c4d05969d4f8d17a08c229c2f4ff3c108", size = 10739177, upload-time = "2026-05-21T14:34:37.332Z" },
-    { url = "https://files.pythonhosted.org/packages/45/91/254a35c20acc38a7223c9d2d594af12e794432464f2cdeb52af1dc4a892d/ruff-0.15.14-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:be4ff55af755bd71a00ab3dc6bd7ffc467bd76e0df6881e286c2e3d23e8fb43b", size = 11144969, upload-time = "2026-05-21T14:34:43.978Z" },
-    { url = "https://files.pythonhosted.org/packages/56/9e/d13e40f83b8d0a94430e6778ce1d94a43b38cf2efe63278bdd2b4c65abbf/ruff-0.15.14-py3-none-macosx_11_0_arm64.whl", hash = "sha256:48d5909d7d06276ce7dde6d32bfa4b0d4cb2651145cd8ee4b440722cbc77832f", size = 10478207, upload-time = "2026-05-21T14:34:48.378Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/f1/b15a7839fa4f332f8acec78e20564f26bb2d866e3d21710b877fd0263000/ruff-0.15.14-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca8cbfa94c4f90984a67561978602746d4cd27103568f745fa90eee3f0d4107d", size = 10818459, upload-time = "2026-05-21T14:34:22.318Z" },
-    { url = "https://files.pythonhosted.org/packages/45/33/53d651177f84f94b400a0e27f8824eeada3dddc9d5ee8aeb048f4352a520/ruff-0.15.14-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9a6bbc0333f1ab053423bcbf6226477d266ca7cec7738c4c8e3f55647803f3c4", size = 10541800, upload-time = "2026-05-21T14:34:20.209Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/a6/868f87e0bf9786ed24b5d0d0ad8676b8a94fd1912f42cddf9cfc7857818a/ruff-0.15.14-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8a24a4f7605d7003a6674d4387651effd939dead3fddd0f36561eb77a9a2e542", size = 11342149, upload-time = "2026-05-21T14:34:46.365Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/8b/38cd5c19faffdcc05a408d2b78edccc69492ab9720eadb49ea15ef80d768/ruff-0.15.14-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:049b5326e53ed80978f2fc041a280603f69dd6b0c95464342a2bb4572d9d9e2f", size = 12212563, upload-time = "2026-05-21T14:34:28.579Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/4d/a3c5b874a556d5731e3e657aaf04311bb76f0a5c3ec220ed43051be6b64b/ruff-0.15.14-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4ed42e6696c8dfa5f06728e6441993901f548eb92d73bc472cb5a38d1395fbf", size = 11493299, upload-time = "2026-05-21T14:34:41.836Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/c0/56472c251d09858a53e51efbd485b09e1995d8731668b76d52e5dd6ee0f1/ruff-0.15.14-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:715c543cf450c4888251f91c52f1942a800541d9bddd7ac060aa4e6b77ae7cba", size = 11455931, upload-time = "2026-05-21T14:34:57.276Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/4a/e2e7b4d8dbf233d4eace59c75bc3435fa6d8bd3bae82d351d4e4300c0fd1/ruff-0.15.14-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:72ebab6013ec887d439d8b7593737a0a4ffb06d45d209d4e4bf2e92813082d3f", size = 11400794, upload-time = "2026-05-21T14:34:39.773Z" },
-    { url = "https://files.pythonhosted.org/packages/97/c7/83c0539fe34c3e09136204d1e75d6052492364e0b3cb05e9465423f567d7/ruff-0.15.14-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:49072d36abdbe97a8dd7f480afe9c675699c0c495d4c84076e2c1203c4550581", size = 10804759, upload-time = "2026-05-21T14:34:31.045Z" },
-    { url = "https://files.pythonhosted.org/packages/86/a6/18f2bfc095a2ab4a78745644e428205532ce6653a5d0fa8501572891534d/ruff-0.15.14-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:958522aee105068640c2c2ceae08f413ae44d922f52a1374ac13d6a96032fc93", size = 10539517, upload-time = "2026-05-21T14:34:53.064Z" },
-    { url = "https://files.pythonhosted.org/packages/54/3a/5a8b3b69c654d4e4bf1d246ac5b49cbcdac6eaab6905925f8915f31e3b80/ruff-0.15.14-py3-none-musllinux_1_2_i686.whl", hash = "sha256:f3707da619a143a2e8830e2abab8224478d69ace2d28cb6c20543ae97c36bf61", size = 11065169, upload-time = "2026-05-21T14:34:24.484Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/c5/8864e4e7925b836ea354b31d57641ec03830564e281a8b6f061f8c3e0ec1/ruff-0.15.14-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:bb01d645694e3ec0102105d07ef2d53703970407d59c04e59d3ba0b7a1d53553", size = 11560214, upload-time = "2026-05-21T14:34:50.975Z" },
-    { url = "https://files.pythonhosted.org/packages/36/38/012bf76752e1f89ed50b77b99532d90f3a3e287bc7918e1fc0948ac866ac/ruff-0.15.14-py3-none-win32.whl", hash = "sha256:6d0c1ad2a0ab718d39b6d8fd2217981ce4d625cd96a720095f798fb47d8b13e6", size = 10805548, upload-time = "2026-05-21T14:34:33.453Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/b7/4ea2c170f10ad760fff2a5250beb18897719dc8b52b53a24cddbb9dd3f19/ruff-0.15.14-py3-none-win_amd64.whl", hash = "sha256:802342981e056db3851a7836e5b070f8f15f67d4a685ae2a6160939d364b2902", size = 11939523, upload-time = "2026-05-21T14:34:18.077Z" },
-    { url = "https://files.pythonhosted.org/packages/62/d5/bc97ff895ec35cf3925d4bd60f3b39d822f377a446906ec9bcc87405e59b/ruff-0.15.14-py3-none-win_arm64.whl", hash = "sha256:ff47b90a9ef6a40c9e2f3b479c1fb78531adf055b94c1eba0a7ba04b31951826", size = 11208607, upload-time = "2026-05-21T14:34:26.525Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/9d/3a45c05b8ab04b4705989de70a79008e27c8003296a0feaee9edc18dd7e9/ruff-0.15.15-py3-none-linux_armv6l.whl", hash = "sha256:cf93e5388f412e1b108b1f8b34a6e036b70fe8aff89393befad96fe48670311b", size = 10710652, upload-time = "2026-05-28T14:16:06.701Z" },
+    { url = "https://files.pythonhosted.org/packages/05/66/da974431624bf3b49f6ee1f9543c02d929ff1cba78b0d5a79c38cf21f744/ruff-0.15.15-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ac5a646d1f6a7dadd5d50842dae2c1f9862ac887ef5d1b1375e02def791fde6e", size = 11096615, upload-time = "2026-05-28T14:16:23.313Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/09/7443452e5d290230a712103f2fdceeef7184f3ec99a2bd01c8be78aaceb5/ruff-0.15.15-py3-none-macosx_11_0_arm64.whl", hash = "sha256:77d955a431430c66f72dd94e379ad38a16daea3d25094872ac4edf9e797be530", size = 10436683, upload-time = "2026-05-28T14:16:40.974Z" },
+    { url = "https://files.pythonhosted.org/packages/53/01/d330c26a57fa4f3943a14424904027428315b700fe4d14a84bb123a649e5/ruff-0.15.15-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7614ee79c69788cf6cedd568069ade9cecc22a1ad20494efe8d0c9ebb4b622d4", size = 10769064, upload-time = "2026-05-28T14:16:28.905Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/85/cc8770f8bdff541b1da8392d1634141fe4a0e3f4ee596605959b7906c27f/ruff-0.15.15-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3cdb1679e06a1f6b47bc384714ae96f6e2fb65ca441eb78c43d2ca554176ce1f", size = 10511987, upload-time = "2026-05-28T14:16:43.732Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/29/8c190c1472b63013583ba391f3342036e02010544c1270455ed8e519bdf3/ruff-0.15.15-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2728b93d7b23a603ea2c0ac6eb73d760bd38ec9de35f35fb41e18f7a3fee7622", size = 11275100, upload-time = "2026-05-28T14:16:55.244Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/6b/7e145ce2cc8e63d6834eca03d83a0e18d121def5c69f91b4cf4011ed4879/ruff-0.15.15-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be582fcc0db438902c7792b08d6ddf6c9b9e21addaa10092c2c741cfb09e5a45", size = 12176903, upload-time = "2026-05-28T14:16:14.368Z" },
+    { url = "https://files.pythonhosted.org/packages/80/a3/d5974637f68e451f7fadf015cf3101d1cd7d8ba5027cffe0b9e3826ebe6b/ruff-0.15.15-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7aa77465b8ecaf1a27bea098d696f7fed5e1eccbd10b321b682d6de586ae5627", size = 11404550, upload-time = "2026-05-28T14:16:20.138Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/1c/e6e5e568f22be4fb05d6244234aba384c06b451252453b821e1a529263cf/ruff-0.15.15-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48decfa11d740de4889de623be1463308346312f2409a56e24aa280c86162dc4", size = 11382027, upload-time = "2026-05-28T14:16:46.615Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/01/170921b49fcd2e8858825593f91cf7146c3e40a5c3e6df763e4bb0484dde/ruff-0.15.15-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a5015088452ca0081387063649ec67f06d3d1d6b8b936a1f836b5e9657ecd48c", size = 11366041, upload-time = "2026-05-28T14:16:26.247Z" },
+    { url = "https://files.pythonhosted.org/packages/87/54/a7bad711d7de93254e15e06a4c375b89a03d18de45d3e5dcc86a4472fb1a/ruff-0.15.15-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f5294aab6356c81600fcdea3a62bb1b924dfd5e91767c12318d3f68f86af57cd", size = 10741795, upload-time = "2026-05-28T14:16:17.11Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/38c075963668f8b41c6914ee0f6f318727fbe30ab9145cb29e6df464c5fa/ruff-0.15.15-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:db5bd4d802415cca656dc1616070b725952d6ae95eb5d4831e49fbd94a38f75f", size = 10511117, upload-time = "2026-05-28T14:16:31.767Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/96/6ff689e1f7e375d1d97075eca022f74c2bab59554a432fe4d2e6f091986a/ruff-0.15.15-py3-none-musllinux_1_2_i686.whl", hash = "sha256:587a6278ed42059191c1a466e490bd7930fb50bd2e255398bc29616c895a61cb", size = 10994867, upload-time = "2026-05-28T14:16:35.149Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c2/5dce0ab9f92a8d534fa62b9bf9caca3eddb8c1a81b616f5e195ada4f0d6e/ruff-0.15.15-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:df0c1c084f5f4be9812f61518a45c440d3c30d69ce4bf6c5270e66d38338f02a", size = 11482101, upload-time = "2026-05-28T14:16:49.598Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/c0/1003b60edd697c649faf61f1a34094b1abb38fb3d1181e3f895781250a08/ruff-0.15.15-py3-none-win32.whl", hash = "sha256:29428ea79694afbe756d45fd59b36f22b6b020dc0443cf7de0173046236964b9", size = 10716774, upload-time = "2026-05-28T14:16:52.337Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a8/1269eddd6945a06c23f055ef7848886e37cf9d6a8bebb386a3115f01470c/ruff-0.15.15-py3-none-win_amd64.whl", hash = "sha256:8df0323902e15e24bc4bf246da830573d3cf3352bd0b9a164eab335d111ff4a4", size = 11868463, upload-time = "2026-05-28T14:16:11.333Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b2/920464c907b191e37469d477a1aa8bc048b8f36c4c1610dfa4ab87b39e18/ruff-0.15.15-py3-none-win_arm64.whl", hash = "sha256:3c8ceca6792f38196b8f589bc92eccd03eef286602da92e5dc05cc42ef6441b7", size = 11138498, upload-time = "2026-05-28T14:16:38.425Z" },
 ]
 
 [[package]]
@@ -641,4 +667,13 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c7/79/12135bdf8b9c9367b8701c2c19a14c913c120b882d50b014ca0d38083c2c/wsproto-1.3.2.tar.gz", hash = "sha256:b86885dcf294e15204919950f666e06ffc6c7c114ca900b060d6e16293528294", size = 50116, upload-time = "2025-11-20T18:18:01.871Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl", hash = "sha256:61eea322cdf56e8cc904bd3ad7573359a242ba65688716b0710a5eb12beab584", size = 24405, upload-time = "2025-11-20T18:18:00.454Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
 ]


### PR DESCRIPTION
Update charm libraries via `charmcraft fetch-lib` and fix breaking change in prometheus_remote_write lib.

Closes #29 

## Changes

- Update `service_mesh` lib to 0.19
- Update `loki_push_api` lib to 1.25
- Update `prometheus_remote_write` lib to 1.12
  - Add required `peer_relation_name="k6"` parameter to `PrometheusRemoteWriteConsumer`